### PR TITLE
Added arguments to repr.OmitEmpty() calls

### DIFF
--- a/_examples/ini/main.go
+++ b/_examples/ini/main.go
@@ -50,5 +50,5 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	repr.Println(ini, repr.Indent("  "), repr.OmitEmpty())
+	repr.Println(ini, repr.Indent("  "), repr.OmitEmpty(true))
 }

--- a/_examples/sql/main.go
+++ b/_examples/sql/main.go
@@ -170,5 +170,5 @@ func main() {
 	sql := &Select{}
 	err := sqlParser.ParseString(*sqlArg, sql)
 	kingpin.FatalIfError(err, "")
-	repr.Println(sql, repr.Indent("  "), repr.OmitEmpty())
+	repr.Println(sql, repr.Indent("  "), repr.OmitEmpty(true))
 }


### PR DESCRIPTION
A recent change in https://github.com/alecthomas/repr changed the
syntax of the repr.OmitEmpty() function to require an argument.  Two
examples call this function but were not updated to support the change.