### PR TITLE
Added support for custom scanner as well as parsing of comments.

### DIFF
--- a/lexer/text_scanner_test.go
+++ b/lexer/text_scanner_test.go
@@ -39,6 +39,19 @@ func TestLexBacktickString(t *testing.T) {
 	assert.Equal(t, lexer.Next(), Token{Type: scanner.String, Value: "hello\\nworld", Pos: Position{Line: 1, Column: 1}})
 }
 
+func TestLexComments(t *testing.T) {
+	lexer := LexComments(strings.NewReader("// hello world\n/* more comments */"))
+	helloPos := Position{Offset: 0, Line: 1, Column: 1}
+	morePos := Position{Offset: 14, Line: 1, Column: 15}
+	assert.Equal(t, Token{Type: scanner.Comment, Value: "// hello world", Pos: helloPos}, lexer.Next())
+	assert.Equal(t, Token{Type: scanner.Comment, Value: "/* more comments */", Pos: morePos}, lexer.Next())
+}
+
+func TestLexNoComments(t *testing.T) {
+	lexer := LexString("// hello world\n/* more comments */")
+	assert.Equal(t, Token{Type: scanner.EOF, Value: "", Pos: Position{Line: 1, Column: 1}}, lexer.Next())
+}
+
 func BenchmarkTextScannerLexer(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		lex := TextScannerLexer.Lex(strings.NewReader("hello world 123 hello world 123"))


### PR DESCRIPTION
This should cover the use cases for parsing comments so that they are not ignored as mentioned in #7 

Added new definition CommentScannerLexer
Added new constructor LexComments that enables comments in the text/scanner
Added new constructor LexScanner that takes in a scanner.
Updated the thrift example to read comments and optionally use the --parseComments arg when testing Thrift files.