### PR TITLE
Fix a few potential cases of "unexpected error interface conversion"

### DIFF
--- a/grammar.go
+++ b/grammar.go
@@ -1,6 +1,7 @@
 package participle
 
 import (
+	"fmt"
 	"reflect"
 	"text/scanner"
 
@@ -38,7 +39,7 @@ func (g *generatorContext) parseType(t reflect.Type) node {
 		slexer := lexStruct(t)
 		defer func() {
 			if msg := recover(); msg != nil {
-				panic(slexer.Field().Name + ": " + msg.(string))
+				panic(fmt.Sprintf("%s: %s", slexer.Field().Name, msg))
 			}
 		}()
 		e := g.parseExpression(slexer)

--- a/nodes.go
+++ b/nodes.go
@@ -30,7 +30,7 @@ type node interface {
 
 func decorate(name string) {
 	if msg := recover(); msg != nil {
-		panic(name + ": " + msg.(string))
+		panic(fmt.Sprintf("%s: %s", name, msg))
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -3,6 +3,7 @@ package participle
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -56,7 +57,7 @@ func Build(grammar interface{}, lex lexer.Definition) (parser *Parser, err error
 func (p *Parser) Parse(r io.Reader, v interface{}) (err error) {
 	defer func() {
 		if msg := recover(); msg != nil {
-			err = errors.New(msg.(string))
+			err = fmt.Errorf("%s", msg)
 		}
 	}()
 	lex := p.lex.Lex(r)


### PR DESCRIPTION
I've found a case where the parser returns an error saying `unexpected error interface conversion: interface {} is *lexer.Error, not string`. It turned out that (probably not surprisingly) there was indeed an issue on my side, which that one obscured. This approach should work pretty generically for any error type.

Thanks for the package as well, it's a neat approach which is great to work with!