### PR TITLE
Fix for Go1.11 change in text/scanner returning RawString for raw string literals

### DIFF
--- a/lexer/text_scanner_go110_test.go
+++ b/lexer/text_scanner_go110_test.go
@@ -1,0 +1,17 @@
+// +build !go1.11
+
+package lexer
+
+import (
+	"testing"
+	"text/scanner"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLexBacktickString(t *testing.T) {
+	lexer := LexString("`hello\\nworld`")
+	token := lexer.Next()
+	// See https://github.com/golang/go/issues/23675.  Go 1.11 fixes token type into RawString.
+	require.Equal(t, Token{Type: scanner.String, Value: "hello\\nworld", Pos: Position{Line: 1, Column: 1}}, token)
+}

--- a/lexer/text_scanner_go111_test.go
+++ b/lexer/text_scanner_go111_test.go
@@ -1,0 +1,16 @@
+// +build go1.11
+
+package lexer
+
+import (
+	"testing"
+	"text/scanner"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLexBacktickString(t *testing.T) {
+	lexer := LexString("`hello\\nworld`")
+	token := lexer.Next()
+	require.Equal(t, Token{Type: scanner.RawString, Value: "hello\\nworld", Pos: Position{Line: 1, Column: 1}}, token)
+}

--- a/lexer/text_scanner_test.go
+++ b/lexer/text_scanner_test.go
@@ -37,12 +37,6 @@ func TestLexSingleString(t *testing.T) {
 	require.Equal(t, Token{Type: scanner.Char, Value: "\U00008a9e", Pos: Position{Line: 1, Column: 1}}, token)
 }
 
-func TestLexBacktickString(t *testing.T) {
-	lexer := LexString("`hello\\nworld`")
-	token := lexer.Next()
-	require.Equal(t, Token{Type: scanner.String, Value: "hello\\nworld", Pos: Position{Line: 1, Column: 1}}, token)
-}
-
 func BenchmarkTextScannerLexer(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		lex := TextScannerLexer.Lex(strings.NewReader("hello world 123 hello world 123"))


### PR DESCRIPTION
Fix for Go1.11 change in text/scanner returning RawString for raw string literals

See https://go.googlesource.com/go/+/c8915a0696ddb53399e9c7ebae1cd1158f271756.