### PR TITLE
participle/lexer: update error comparison to support Go1.13

### DIFF
--- a/lexer/text_scanner.go
+++ b/lexer/text_scanner.go
@@ -53,7 +53,7 @@ func Lex(r io.Reader) Lexer {
 	lexer := lexWithScanner(r, &scanner.Scanner{})
 	lexer.scanner.Error = func(s *scanner.Scanner, msg string) {
 		// This is to support single quoted strings. Hacky.
-		if msg != "illegal char literal" {
+		if !strings.HasSuffix(msg, "char literal") {
 			lexer.err = Errorf(Position(lexer.scanner.Pos()), msg)
 		}
 	}


### PR DESCRIPTION
https://golang.org/cl/161199 updated text/scanner error messages for
upcoming Go1.13.

Error message pre-1.13 contains "illegal char literal" while 1.13
changes it to "invalid char literal".

Fixes #50