### PR TITLE
Fix type in go's structure for correct matching conditions

### DIFF
--- a/_examples/sql/main.go
+++ b/_examples/sql/main.go
@@ -50,7 +50,7 @@ type AliasedExpression struct {
 }
 
 type Expression struct {
-	And *AndCondition `@@ { "OR" @@ }`
+	And []*AndCondition `@@ { "OR" @@ }`
 }
 
 type AndCondition struct {


### PR DESCRIPTION
Hi, I'm making this example simplyer for my own purpose and found, that query like
```
SELECT xxx FROM (
  SELECT * FROM zzz
    WHERE attr_name = 'yyy' AND (attr_value_int = 0 OR attr_value_str = '0') AND (attr_value_bool = TRUE OR event_name IS NOT NULL)
    GROUP BY uuid
 )
 WHERE date > '2019-05-20 06:01:06' AND date < '2019-05-22 00:00:00' AND event_id IN (42, 12)
 LIMIT 100
```

with current data structure not handled conditions after 'OR', attr_value_str for example.