### PR TITLE
Allow expected token in lexer error to be exported as a field.

### DIFF
--- a/error.go
+++ b/error.go
@@ -20,16 +20,23 @@ type Error interface {
 // UnexpectedTokenError is returned by Parse when an unexpected token is encountered.
 //
 // This is useful for composing parsers in order to detect when a sub-parser has terminated.
-type UnexpectedTokenError struct{ lexer.Token }
+type UnexpectedTokenError struct {
+	Unexpected lexer.Token
+	Expected   string
+}
 
 func (u UnexpectedTokenError) Error() string {
-	return lexer.FormatError(u.Pos, u.Message())
+	return lexer.FormatError(u.Unexpected.Pos, u.Message())
 }
 
 func (u UnexpectedTokenError) Message() string { // nolint: golint
-	return fmt.Sprintf("unexpected token %q", u.Value)
+	var expected string
+	if u.Expected != "" {
+		expected = fmt.Sprintf(" (expected %s)", u.Expected)
+	}
+	return fmt.Sprintf("unexpected token %q%s", u.Unexpected.Value, expected)
 }
-func (u UnexpectedTokenError) Position() lexer.Position { return u.Pos } // nolint: golint
+func (u UnexpectedTokenError) Position() lexer.Position { return u.Unexpected.Pos } // nolint: golint
 
 type parseError struct {
 	Message string

--- a/nodes.go
+++ b/nodes.go
@@ -242,7 +242,7 @@ func (s *sequence) Parse(ctx *parseContext, parent reflect.Value) (out []reflect
 			if err != nil {
 				return nil, err
 			}
-			return out, lexer.Errorf(token.Pos, "unexpected %q (expected %s)", token, n)
+			return out, UnexpectedTokenError{token, n.String()}
 		}
 	}
 	return out, nil

--- a/parser.go
+++ b/parser.go
@@ -190,7 +190,7 @@ func (p *Parser) parseOne(ctx *parseContext, rv reflect.Value) error {
 	if err != nil {
 		return err
 	} else if !token.EOF() && !ctx.allowTrailing {
-		return ctx.DeepestError(UnexpectedTokenError{token})
+		return ctx.DeepestError(UnexpectedTokenError{Unexpected: token})
 	}
 	return nil
 }
@@ -208,7 +208,7 @@ func (p *Parser) parseInto(ctx *parseContext, rv reflect.Value) error {
 	}
 	if pv == nil {
 		token, _ := ctx.Peek(0)
-		return ctx.DeepestError(UnexpectedTokenError{token})
+		return ctx.DeepestError(UnexpectedTokenError{Unexpected: token})
 	}
 	return nil
 }
@@ -221,14 +221,14 @@ func (p *Parser) rootParseable(ctx *parseContext, parseable Parseable) error {
 	err = parseable.Parse(ctx.PeekingLexer)
 	if err == NextMatch {
 		token, _ := ctx.Peek(0)
-		return ctx.DeepestError(UnexpectedTokenError{token})
+		return ctx.DeepestError(UnexpectedTokenError{Unexpected: token})
 	}
 	peek, err = ctx.Peek(0)
 	if err != nil {
 		return err
 	}
 	if !peek.EOF() && !ctx.allowTrailing {
-		return ctx.DeepestError(UnexpectedTokenError{peek})
+		return ctx.DeepestError(UnexpectedTokenError{Unexpected: peek})
 	}
 	return nil
 }


### PR DESCRIPTION
Hi @alecthomas, I wanted to extract the expected token to help writing a more nuanced error reporting for my DSL. Would you be open to strongly typing this field?