### PR TITLE
Expose parser's built lexer

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -97,6 +97,11 @@ func Build(grammar interface{}, options ...Option) (parser *Parser, err error) {
 	return p, nil
 }
 
+// Lexer returns the parser's builtin lexer.
+func (p *Parser) Lexer() lexer.Definition {
+	return p.lex
+}
+
 // Lex uses the parser's lexer to tokenise input.
 func (p *Parser) Lex(r io.Reader) ([]lexer.Token, error) {
 	lex, err := p.lex.Lex(r)


### PR DESCRIPTION
Hi @alecthomas, I have a use case where I wanted to build a parser with a mapper option like `participle.Unquote()`, but also gain access to the peeking lexer via `parser.ParseFromLexer`. I noticed that part of `participle.Build` a `mappingLexerDef` is constructed over the passed in lexer, but this is not an exported field so I'm not able to utilize the unquote mapper. Exposing the parser's via `(p *Parser) Lexer() lexer.Definition` will let me fulfill my usecase.

Example:
```go
parser = participle.MustBuild(&AST{}, participle.Lexer(myLexer), participle.Unquote())

lex, _ := parser.Lexer().Lex(reader)

peeker, _ := lexer.Upgrade(lex)

ast := &AST{}
err = parser.ParseFromLexer(peeker, ast)
```