### PR TITLE
Expose the length of tokens in the peeking lexer

### DIFF
--- a/lexer/peek.go
+++ b/lexer/peek.go
@@ -29,6 +29,11 @@ func (p *PeekingLexer) Cursor() int {
 	return p.cursor
 }
 
+// Length returns the number of tokens consumed by the lexer.
+func (p *PeekingLexer) Length() int {
+	return len(p.tokens)
+}
+
 // Next consumes and returns the next token.
 func (p *PeekingLexer) Next() (Token, error) {
 	if p.cursor >= len(p.tokens) {


### PR DESCRIPTION
Hi @alecthomas, here with another use case. I'm not actually sure what's the best way to solve this so I'll first explain what I'm trying to do.

I'm using the peeking lexer to help write error reporting. Often I find myself wanting to know what is the cursor position of the unexpected token in the peeking lexer.

However, the peeking lexer counts in number of tokens, and the unexpected token only has its file position. And when the unexpected token error occurs, the token may be ahead or behind the cursor position 0. How do I reliable find the relative cursor position for this token?

My current solution is binary searching for it using the token's offset, but that requires exposes the peeking lexer's `Length()`:
```go
func searchToken(lex *lexer.PeekingLexer, tokenOffset int) (lexer.Token, int, error) {
	cursorOffset, err := binarySearchLexer(lex, 0, lex.Length(), tokenOffset)
	if err != nil {
		return lexer.Token{}, 0, err
	}

	if cursorOffset < 0 {
		return lexer.Token{}, 0, fmt.Errorf("failed to find token at offset %d", tokenOffset)
	}

	n := cursorOffset - lex.Cursor()
	token, err := lex.Peek(n)
	return token, n, err
}

func binarySearchLexer(lex *lexer.PeekingLexer, l, r, x int) (int, error) {
	if r >= l {
		mid := l + (r - l) / 2

		token, err := lex.Peek(mid - lex.Cursor())
		if err != nil {
			return 0, err
		}

		if token.Pos.Offset == x {
			return mid, nil
		}

		if token.Pos.Offset > x {
			return binarySearchLexer(lex, l, mid-1, x)
		}

		return binarySearchLexer(lex, mid+1, r, x)
	}

	return -1, nil
}
```