### PR TITLE
Fix division on the BASIC interpreter

### DIFF
--- a/_examples/basic/eval.go
+++ b/_examples/basic/eval.go
@@ -80,7 +80,7 @@ func (o *OpFactor) Evaluate(ctx *Context, lhs interface{}) (interface{}, error) 
 	case "*":
 		return lhsNumber * rhsNumber, nil
 	case "/":
-		return lhsNumber * rhsNumber, nil
+		return lhsNumber / rhsNumber, nil
 	}
 	panic("unreachable")
 }


### PR DESCRIPTION
Due to a typo in the BASIC interpreter, it was mistakenly multiplying when the "/" was used.