### PR TITLE
Return peeking lexer on error to allow partial AST parsing

### DIFF
--- a/lexer/peek.go
+++ b/lexer/peek.go
@@ -13,7 +13,7 @@ func Upgrade(lex Lexer) (*PeekingLexer, error) {
 	for {
 		t, err := lex.Next()
 		if err != nil {
-			return nil, err
+			return r, err
 		}
 		if t.EOF() {
 			r.eof = t


### PR DESCRIPTION
When I get a lexer error, for example, an unterminated string, I still want to parse the tokens consumed so far into an AST. I'm using the AST to implement a LSP langserver, and I want to use the partial AST to continue syntax highlight the rest of the document.