### PR TITLE
Fix AND and OR precedence in SQL example

### DIFF
--- a/_examples/sql/main.go
+++ b/_examples/sql/main.go
@@ -50,11 +50,11 @@ type AliasedExpression struct {
 }
 
 type Expression struct {
-	And []*AndCondition `@@ { "OR" @@ }`
+	Or []*OrCondition `@@ { "OR" @@ }`
 }
 
-type AndCondition struct {
-	Or []*Condition `@@ { "AND" @@ }`
+type OrCondition struct {
+	And []*Condition `@@ { "AND" @@ }`
 }
 
 type Condition struct {


### PR DESCRIPTION
Hey. Was playing with your awesome lib and noticed that. Specs: http://www.h2database.com/html/grammar.html#expression