### PR TITLE
Custom bool type results in error message

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -563,6 +563,10 @@ func setField(pos lexer.Position, strct reflect.Value, field structLexerField, f
 		}
 
 	case reflect.Bool, reflect.Struct:
+		if f.Kind() == reflect.Bool && fv.Kind() == reflect.Bool {
+			f.SetBool(fv.Bool())
+			break
+		}
 		if fv.Type() != f.Type() {
 			return fmt.Errorf("value %q is not correct type %s", fv, f.Type())
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1103,3 +1103,53 @@ func TestDisjunctionErrorReporting(t *testing.T) {
 	// TODO: This should produce a more useful error. This is returned by sequence.Parse().
 	require.EqualError(t, err, `1:7: unexpected token "foo" (expected "}")`)
 }
+
+func TestCustomInt(t *testing.T) {
+	type MyInt int
+	type G struct {
+		Value MyInt `@Int`
+	}
+
+	p, err := Build(&G{})
+	require.NoError(t, err)
+
+	g := &G{}
+	err = p.ParseString(`42`, g)
+	require.NoError(t, err)
+	require.Equal(t, &G{42}, g)
+}
+
+func TestBoolIfSet(t *testing.T) {
+	type G struct {
+		Value bool `@"true"?`
+	}
+
+	p, err := Build(&G{})
+	require.NoError(t, err)
+
+	g := &G{}
+	err = p.ParseString(`true`, g)
+	require.NoError(t, err)
+	require.Equal(t, &G{true}, g)
+	err = p.ParseString(``, g)
+	require.NoError(t, err)
+	require.Equal(t, &G{false}, g)
+}
+
+func TestCustomBoolIfSet(t *testing.T) {
+	type MyBool bool
+	type G struct {
+		Value MyBool `@"true"?`
+	}
+
+	p, err := Build(&G{})
+	require.NoError(t, err)
+
+	g := &G{}
+	err = p.ParseString(`true`, g)
+	require.NoError(t, err)
+	require.Equal(t, &G{true}, g)
+	err = p.ParseString(``, g)
+	require.NoError(t, err)
+	require.Equal(t, &G{false}, g)
+}


### PR DESCRIPTION
While integrating your library into my project, I stumbled over an issue when I introduced custom types. One of them was of the kind `type MyBool bool`, and I received following error message:

    value %!q(bool=true) is not correct type MyBool

I traced this down to somewhat strange behavior when comparing those types, at least if compared to how `type MyInt int` values are handled. I was able to reproduce this in test cases and provide a fix, but am not really sure whether my fix is the right way to fix the issue, I didn't really understand what's wrong here.

I think I'm at least correct on the test case showing unexpected behavior. I split into two commits, so you simply cherry-pick the test cases if you see a better way to fix this. At least I did not break any of the existing test cases.

## Commit 1:  Test case illustrating custom bool type issue

This commit adds three new test cases:

1. `TestCustomInt`: parses into a custom int type, runs fine
2. `TestBoolIfSet`: parses into a bool value if token is set, runs fine
3. `TestCustomBoolIfSet`: combines (1) and (2), and tries to parse into a
   custom bool type. Unexpectedly, fails with error message:

       value %!q(bool=true) is not correct type MyBool

## Commit 2:  Support for parsing to custom boolean types

For some reason, custom boolean types are not comparable using
`fv.Type() == f.Type()`, like it works fine for other custom types.
`.Kind()` returns the correct kind anyway in both cases, and `.SetBool()`
also works as expected. Fixes `TestCustomBoolIfSet` test case, but this
feels more like a workaround than a fix to the actual issue.