### PR TITLE
Update main.go

### DIFF
--- a/_examples/microc/main.go
+++ b/_examples/microc/main.go
@@ -116,7 +116,7 @@ type Stmt struct {
 	WhileStmt  *WhileStmt  `| @@`
 	Block      *Stmts      `| "{" @@ "}"`
 	Expr       *Expr       `| @@`
-	Empty      bool        `| ";"`
+	Empty      bool        `| @";"`
 }
 
 type FunBody struct {


### PR DESCRIPTION
@ was missing for successful bool capture. without @ looks like Empty is always false.