### PR TITLE
Add support for parser negative lookahead #134

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The grammar format is:
 - `<expr> <expr> ...` Match expressions.
 - `<expr> | <expr> | ...` Match one of the alternatives. Each alternative is tried in order, with backtracking.
 - `!<expr>` Match any token that is _not_ the start of the expression (eg: `@!";"` matches anything but the `;` character into the field).
+- `!?<expr>` Negative lookahead - the sequence will not match if this expression matches (lookahead won't be consumed)
 
 The following modifiers can be used after any expression:
 

--- a/ebnf.go
+++ b/ebnf.go
@@ -102,6 +102,9 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 
 	case *negation:
 		p.out += "!"
+		if !n.consume {
+			p.out += "?"
+		}
 		buildEBNF(false, n.node, seen, p, outp)
 		return
 

--- a/ebnf_test.go
+++ b/ebnf_test.go
@@ -14,12 +14,13 @@ EBNF = Production* .
 Production = <ident> "=" Expression+ "." .
 Expression = Sequence ("|" Sequence)* .
 Sequence = Term+ .
-Term = <ident> | Literal | Range | Group | EBNFOption | Repetition .
+Term = <ident> | Literal | Range | Group | EBNFOption | Repetition | Negation .
 Literal = <string> .
 Range = <string> "…" <string> .
 Group = "(" Expression ")" .
 EBNFOption = "[" Expression "]" .
 Repetition = "{" Expression "}" .
+Negation = "!" "?"? Expression .
 `
 	require.Equal(t, strings.TrimSpace(expected), parser.String())
 }

--- a/grammar.go
+++ b/grammar.go
@@ -288,13 +288,21 @@ func (g *generatorContext) parseGroup(slexer *structLexer) (node, error) {
 // A token negation
 //
 // Accepts both the form !"some-literal" and !SomeNamedToken
+// If used as !?<term>, it functions as negative lookahead, not consuming any token
 func (g *generatorContext) parseNegation(slexer *structLexer) (node, error) {
 	_, _ = slexer.Next() // advance the parser since we have '!' right now.
-	next, err := g.parseTermNoModifiers(slexer)
+	neg := &negation{}
+	modifier, err := slexer.Peek()
 	if err != nil {
 		return nil, err
 	}
-	return &negation{next}, nil
+	if neg.consume = modifier.Type != '?'; !neg.consume {
+		_, _ = slexer.Next()
+	}
+	if neg.node, err = g.parseTermNoModifiers(slexer); err != nil {
+		return nil, err
+	}
+	return neg, nil
 }
 
 // A literal string.

--- a/nodes.go
+++ b/nodes.go
@@ -464,7 +464,8 @@ func (l *literal) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.
 }
 
 type negation struct {
-	node node
+	node    node
+	consume bool
 }
 
 func (n *negation) String() string   { return ebnf(n) }
@@ -490,7 +491,11 @@ func (n *negation) Parse(ctx *parseContext, parent reflect.Value) (out []reflect
 		return nil, Errorf(notEOF.Pos, "unexpected '%s'", notEOF.Value)
 	}
 
-	// Just give the next token
+	if !n.consume {
+		// Non-consuming mode - nil means no match, empty slice means successful but empty match
+		return []reflect.Value{}, nil
+	}
+	// Consuming mode - just give the next token
 	next, err := ctx.Next()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Support for parser negative lookahead, i.e. a term saying the following expression cannot be matched. Works very much like existing negation, except it doesn't consume any tokens. Allows for example resolving grammar conflicts by blacklisting some keywords for a sub-expression about to be parsed. See the example in the tests to get the idea. Also explained in this issue: https://github.com/alecthomas/participle/issues/134