### PR TITLE
Lookahead groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ The grammar format is:
 - `<expr> <expr> ...` Match expressions.
 - `<expr> | <expr> | ...` Match one of the alternatives. Each alternative is tried in order, with backtracking.
 - `!<expr>` Match any token that is _not_ the start of the expression (eg: `@!";"` matches anything but the `;` character into the field).
+- `(?= ... )` Positive lookahead group - requires the contents to match further input, without consuming it
+- `(?! ... )` Negative lookahead group - requires the contents not to match further input, without consuming it
 
 The following modifiers can be used after any expression:
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ The grammar format is:
 - `<expr> <expr> ...` Match expressions.
 - `<expr> | <expr> | ...` Match one of the alternatives. Each alternative is tried in order, with backtracking.
 - `!<expr>` Match any token that is _not_ the start of the expression (eg: `@!";"` matches anything but the `;` character into the field).
-- `!?<expr>` Negative lookahead - the sequence will not match if this expression matches (lookahead won't be consumed)
 
 The following modifiers can be used after any expression:
 

--- a/ebnf.go
+++ b/ebnf.go
@@ -132,6 +132,14 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 		case groupMatchOnce:
 		}
 		return
+	case *lookaheadGroup:
+		if !n.negative {
+			p.out += "(?= "
+		} else {
+			p.out += "(?! "
+		}
+		buildEBNF(true, n.expr, seen, p, outp)
+		p.out += ")"
 
 	case *trace:
 		buildEBNF(root, n.node, seen, p, outp)

--- a/ebnf.go
+++ b/ebnf.go
@@ -50,7 +50,6 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 		if !root {
 			p.out += ")"
 		}
-		return
 
 	case *strct:
 		name := strings.ToUpper(n.typ.Name()[:1]) + n.typ.Name()[1:]
@@ -64,7 +63,6 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 		p = &ebnfp{name: name}
 		*outp = append(*outp, p)
 		buildEBNF(true, n.expr, seen, p, outp)
-		return
 
 	case *sequence:
 		group := n.next != nil && !root
@@ -81,7 +79,6 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 		if group {
 			p.out += ")"
 		}
-		return
 
 	case *parseable:
 		p.out += n.t.Name()
@@ -103,7 +100,6 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 	case *negation:
 		p.out += "!"
 		buildEBNF(false, n.node, seen, p, outp)
-		return
 
 	case *literal:
 		p.out += fmt.Sprintf("%q", n.s)
@@ -131,7 +127,7 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 			p.out += "+"
 		case groupMatchOnce:
 		}
-		return
+
 	case *lookaheadGroup:
 		if !n.negative {
 			p.out += "(?= "

--- a/ebnf.go
+++ b/ebnf.go
@@ -102,9 +102,6 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 
 	case *negation:
 		p.out += "!"
-		if !n.consume {
-			p.out += "?"
-		}
 		buildEBNF(false, n.node, seen, p, outp)
 		return
 

--- a/ebnf_test.go
+++ b/ebnf_test.go
@@ -14,13 +14,26 @@ EBNF = Production* .
 Production = <ident> "=" Expression+ "." .
 Expression = Sequence ("|" Sequence)* .
 Sequence = Term+ .
-Term = <ident> | Literal | Range | Group | EBNFOption | Repetition | Negation .
+Term = <ident> | Literal | Range | Group | LookaheadGroup | EBNFOption | Repetition | Negation .
 Literal = <string> .
 Range = <string> "…" <string> .
 Group = "(" Expression ")" .
+LookaheadGroup = "(" "?" ("=" | "!") Expression ")" .
 EBNFOption = "[" Expression "]" .
 Repetition = "{" Expression "}" .
 Negation = "!" Expression .
 `
 	require.Equal(t, strings.TrimSpace(expected), parser.String())
+}
+
+func TestEBNF_Other(t *testing.T) {
+	type Grammar struct {
+		PositiveLookahead string `  (?= 'good') @Ident`
+		NegativeLookahead string `| (?! 'bad' | "worse") @Ident`
+		Negation          string `| !("anything" | 'but')`
+	}
+
+	parser := mustTestParser(t, &Grammar{})
+	expected := `Grammar = ((?= "good") <ident>) | ((?! "bad" | "worse") <ident>) | !("anything" | "but") .`
+	require.Equal(t, expected, parser.String())
 }

--- a/ebnf_test.go
+++ b/ebnf_test.go
@@ -20,7 +20,7 @@ Range = <string> "…" <string> .
 Group = "(" Expression ")" .
 EBNFOption = "[" Expression "]" .
 Repetition = "{" Expression "}" .
-Negation = "!" "?"? Expression .
+Negation = "!" Expression .
 `
 	require.Equal(t, strings.TrimSpace(expected), parser.String())
 }

--- a/grammar.go
+++ b/grammar.go
@@ -133,12 +133,11 @@ func (g *generatorContext) parseTermNoModifiers(slexer *structLexer) (node, erro
 	if err != nil {
 		return nil, err
 	}
-	var out node
 	switch t.Type {
 	case '@':
-		out, err = g.parseCapture(slexer)
+		return g.parseCapture(slexer)
 	case scanner.String, scanner.RawString, scanner.Char:
-		out, err = g.parseLiteral(slexer)
+		return g.parseLiteral(slexer)
 	case '!':
 		return g.parseNegation(slexer)
 	case '[':
@@ -149,14 +148,13 @@ func (g *generatorContext) parseTermNoModifiers(slexer *structLexer) (node, erro
 		// Also handles (? used for lookahead groups
 		return g.parseGroup(slexer)
 	case scanner.Ident:
-		out, err = g.parseReference(slexer)
+		return g.parseReference(slexer)
 	case lexer.EOF:
 		_, _ = slexer.Next()
 		return nil, nil
 	default:
 		return nil, nil
 	}
-	return out, err
 }
 
 func (g *generatorContext) parseTerm(slexer *structLexer) (node, error) {

--- a/grammar.go
+++ b/grammar.go
@@ -288,21 +288,13 @@ func (g *generatorContext) parseGroup(slexer *structLexer) (node, error) {
 // A token negation
 //
 // Accepts both the form !"some-literal" and !SomeNamedToken
-// If used as !?<term>, it functions as negative lookahead, not consuming any token
 func (g *generatorContext) parseNegation(slexer *structLexer) (node, error) {
 	_, _ = slexer.Next() // advance the parser since we have '!' right now.
-	neg := &negation{}
-	modifier, err := slexer.Peek()
+	next, err := g.parseTermNoModifiers(slexer)
 	if err != nil {
 		return nil, err
 	}
-	if neg.consume = modifier.Type != '?'; !neg.consume {
-		_, _ = slexer.Next()
-	}
-	if neg.node, err = g.parseTermNoModifiers(slexer); err != nil {
-		return nil, err
-	}
-	return neg, nil
+	return &negation{next}, nil
 }
 
 // A literal string.

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -1,0 +1,40 @@
+package participle_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuild_Errors_Negation(t *testing.T) {
+	type grammar struct {
+		Whatever string `'a' | ! | 'b'`
+	}
+	_, err := participle.Build(&grammar{})
+	require.EqualError(t, err, "Whatever: unexpected token |")
+}
+
+func TestBuild_Errors_Capture(t *testing.T) {
+	type grammar struct {
+		Whatever string `'a' | @ | 'b'`
+	}
+	_, err := participle.Build(&grammar{})
+	require.EqualError(t, err, "Whatever: unexpected token |")
+}
+
+func TestBuild_Errors_UnclosedGroup(t *testing.T) {
+	type grammar struct {
+		Whatever string `'a' | ('b' | 'c'`
+	}
+	_, err := participle.Build(&grammar{})
+	require.EqualError(t, err, `Whatever: expected ) but got "<EOF>"`)
+}
+
+func TestBuild_Errors_LookaheadGroup(t *testing.T) {
+	type grammar struct {
+		Whatever string `'a' | (?? 'what') | 'b'`
+	}
+	_, err := participle.Build(&grammar{})
+	require.EqualError(t, err, `Whatever: expected = or ! but got "?"`)
+}

--- a/nodes.go
+++ b/nodes.go
@@ -424,7 +424,7 @@ type repetition struct {
 }
 
 func (r *repetition) String() string   { return ebnf(r) }
-func (r *repetition) GoString() string { return "repitition{}" }
+func (r *repetition) GoString() string { return "repetition{}" }
 
 // Parse a repetition. Once a repetition is encountered it will always match, so grammars
 // should ensure that branches are differentiated prior to the repetition.

--- a/nodes.go
+++ b/nodes.go
@@ -464,8 +464,7 @@ func (l *literal) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.
 }
 
 type negation struct {
-	node    node
-	consume bool
+	node node
 }
 
 func (n *negation) String() string   { return ebnf(n) }
@@ -491,11 +490,7 @@ func (n *negation) Parse(ctx *parseContext, parent reflect.Value) (out []reflect
 		return nil, Errorf(notEOF.Pos, "unexpected '%s'", notEOF.Value)
 	}
 
-	if !n.consume {
-		// Non-consuming mode - nil means no match, empty slice means successful but empty match
-		return []reflect.Value{}, nil
-	}
-	// Consuming mode - just give the next token
+	// Just give the next token
 	next, err := ctx.Next()
 	if err != nil {
 		return nil, err

--- a/parser_test.go
+++ b/parser_test.go
@@ -1267,7 +1267,6 @@ func TestNegationWithDisjunction(t *testing.T) {
 	err = p.ParseString("", `hello world , `, ast)
 	require.NoError(t, err)
 	require.Equal(t, &[]string{"hello", "world", ","}, ast.EverythingMoreComplex)
-
 }
 
 func TestLookaheadGroup_Positive_SingleToken(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -243,8 +243,7 @@ type Repetition struct {
 }
 
 type Negation struct {
-	NoConsume  bool        `"!" "?"?`
-	Expression *Expression `@@`
+	Expression *Expression `"!" @@`
 }
 
 type Literal struct {


### PR DESCRIPTION
Partially reverts my changes from https://github.com/alecthomas/participle/pull/144 to change the negative lookahead syntax from `!? <expr>` to `(?! <expr> ...)`, in order to have syntax consistent with PERL-like regular expressions. Also adds support for positive lookahead groups, because why not.

Relates to https://github.com/alecthomas/participle/issues/134