### PR TITLE
Fix treating a single-quoted colon string literal as token type specifier

### DIFF
--- a/grammar.go
+++ b/grammar.go
@@ -353,7 +353,7 @@ func (g *generatorContext) parseLiteral(lex *structLexer) (node, error) { // nol
 	if err != nil {
 		return nil, err
 	}
-	if token.Value == ":" && (token.Type == scanner.Char || token.Type == ':') {
+	if token.Type == ':' {
 		_, _ = lex.Next()
 		token, err = lex.Next()
 		if err != nil {

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -38,3 +38,26 @@ func TestBuild_Errors_LookaheadGroup(t *testing.T) {
 	_, err := participle.Build(&grammar{})
 	require.EqualError(t, err, `Whatever: expected = or ! but got "?"`)
 }
+
+func TestBuild_Colon_OK(t *testing.T) {
+	type grammar struct {
+		TokenTypeTest bool   `  'TokenTypeTest'  :   Ident`
+		DoubleCapture string `| 'DoubleCapture' ":" @Ident`
+		SinglePresent bool   `| 'SinglePresent' ':'  Ident`
+		SingleCapture string `| 'SingleCapture' ':' @Ident`
+	}
+	parser, err := participle.Build(&grammar{})
+	require.NoError(t, err)
+	require.Equal(t, `Grammar = "TokenTypeTest"`+
+		` | ("DoubleCapture" ":" <ident>)`+
+		` | ("SinglePresent" ":" <ident>)`+
+		` | ("SingleCapture" ":" <ident>) .`, parser.String())
+}
+
+func TestBuild_Colon_MissingTokenType(t *testing.T) {
+	type grammar struct {
+		Key string `'name' : @Ident`
+	}
+	_, err := participle.Build(&grammar{})
+	require.EqualError(t, err, `Key: expected identifier for literal type constraint but got "@"`)
+}


### PR DESCRIPTION
See https://github.com/alecthomas/participle/issues/146 for explanation.

It seems there was just no reason for accepting `scanner.Char` (i.e. `':'`) as the token type specifier colon.