### PR TITLE
Report errors returned from root `Parseable`

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -238,10 +238,13 @@ func (p *Parser) parseInto(ctx *parseContext, rv reflect.Value) error {
 }
 
 func (p *Parser) rootParseable(ctx *parseContext, parseable Parseable) error {
-	err := parseable.Parse(ctx.PeekingLexer)
-	if err == NextMatch {
-		token := ctx.Peek()
-		return ctx.DeepestError(UnexpectedTokenError{Unexpected: token})
+	if err := parseable.Parse(ctx.PeekingLexer); err != nil {
+		if err == NextMatch {
+			err = UnexpectedTokenError{Unexpected: ctx.Peek()}
+		} else {
+			err = &parseError{Msg: err.Error(), Pos: ctx.Peek().Pos}
+		}
+		return ctx.DeepestError(err)
 	}
 	peek := ctx.Peek()
 	if !peek.EOF() && !ctx.allowTrailing {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,6 +1,7 @@
 package participle_test
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -1711,4 +1712,18 @@ func TestEmptySequenceMatches(t *testing.T) {
 	err := p.ParseString("", "", &actual)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
+}
+
+type RootParseableFail struct{}
+
+func (*RootParseableFail) String() string   { return "" }
+func (*RootParseableFail) GoString() string { return "" }
+func (*RootParseableFail) Parse(lex *lexer.PeekingLexer) error {
+	return errors.New("always fail immediately")
+}
+
+func TestRootParseableFail(t *testing.T) {
+	p := mustTestParser(t, &RootParseableFail{})
+	err := p.ParseString("<test>", "blah", &RootParseableFail{})
+	require.EqualError(t, err, "<test>:1:1: always fail immediately")
 }


### PR DESCRIPTION
This PR ensures that we correctly report the error returned from `Parse` when the grammar's root production implements `Parseable` & returns a non-nil, non-`NextMatch` error

Fixes #228 