### PR TITLE
fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ for each captured token, so eg. `@(Ident Ident Ident)` will be called three time
 
 ### Capturing boolean value
 
-By default a boolean field is used to indicate that a match occurred, which
+By default, a boolean field is used to indicate that a match occurred, which
 turns out to be much more useful and common in Participle than parsing true
 or false literals. For example, parsing a variable declaration with a
 trailing optional syntax:
@@ -228,7 +228,7 @@ type Var struct {
 }
 ```
 
-In practice this gives more useful AST's. If bool were to be parsed literally
+In practice this gives more useful ASTs. If bool were to be parsed literally
 then you'd need to have some alternate type for Optional such as string or a
 custom type.
 
@@ -582,7 +582,7 @@ These related pieces of information can be combined to provide fairly comprehens
 
 ## Comments
 
-Comments can be difficult to capture as in most languagesthey may appear almost
+Comments can be difficult to capture as in most languages they may appear almost
 anywhere. There are three ways of capturing comments, with decreasing fidelity.
 
 The first is to elide tokens in the parser, then add `Tokens []lexer.Token` as a

--- a/options.go
+++ b/options.go
@@ -82,22 +82,22 @@ func ParseTypeWith[T any](parseFn func(*lexer.PeekingLexer) (T, error)) Option {
 }
 
 // Union associates several member productions with some interface type T.
-// Given members X, Y, Z, and W for a union type U, the the EBNF rule is:
+// Given members X, Y, Z, and W for a union type U, then the EBNF rule is:
 //    U = X | Y | Z | W .
 // When the parser encounters a field of type T, it will attempt to parse each member
-// in sequence and take the first matche. Because of this, the order in which the
+// in sequence and take the first match. Because of this, the order in which the
 // members are defined is important. You must be careful to order your members appropriately.
 //
 // An example of a bad parse that can happen if members are out of order:
 //
 // If the first member matches A, and the second member matches A B,
-// and he source string is "AB", then the parser will only match A, and will not
+// and the source string is "AB", then the parser will only match A, and will not
 // try to parse the second member at all.
 func Union[T any](members ...T) Option {
 	return func(p *Parser) error {
 		unionType := reflect.TypeOf((*T)(nil)).Elem()
 		if unionType.Kind() != reflect.Interface {
-			return fmt.Errorf("ParseUnion: union type must be an interface (got %s)", unionType)
+			return fmt.Errorf("Union: union type must be an interface (got %s)", unionType)
 		}
 		memberTypes := make([]reflect.Type, 0, len(members))
 		for _, m := range members {


### PR DESCRIPTION
Found some minor typos while reading the documentation.
I also fixed one error message, it was using the renamed function name ParseUnion.
