### PR TITLE
fix INI parser example from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ parser from the tutorial.
 
  type Value struct {
    String *string  `  @String`
-   Number *float64 `| @Float`
+   Float *float64  `| @Float`
+   Int    *int     `| @Int`
  }
  ```
 
@@ -131,7 +132,7 @@ ast := &INI{}
 err := parser.ParseString("", "size = 10", ast)
 // ast == &INI{
 //   Properties: []*Property{
-//     {Key: "size", Value: &Value{Number: &10}},
+//     {Key: "size", Value: &Value{Int: &10}},
 //   },
 // }
 ```


### PR DESCRIPTION
### What i do

Run the INI example from the README
```golang
type Value struct {
  String *string  `  @String`
  Number *float64 `| @Float`
}
...
ast := &INI{}
err := parser.ParseString("", "size = 10", ast)
// ast == &INI{
//   Properties: []*Property{
//     {Key: "size", Value: &Value{Number: &10}},
//   },
// }
```

### What i get

```golang
Expected nil, but got: participle.UnexpectedTokenError{Unexpected:Token@1:8{-3, "10"}, at:(*participle.sequence)(0xc000026a80)}
```

### Analysis

Grammar states:
```golang
type Value struct {
  String *string  `  @String`
  Number *float64 `| @Float`
}
```
While the input data contains `@Int`, not `@Float`:
```golang
err = parser.ParseString("", "size = 10", ast)
```

So parsing ends with an error.

### Proposed fix

Change the Value definition as follows:

```golang
 type Value struct {
   String *string  `  @String`
   Float *float64  `| @Float`
   Int    *int     `| @Int`
 }
```