### PR TITLE
Genericise the parser.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters:
     - errname
     - nilnil
     - maintidx
+    - unused # Does not work with type parameters
 
 linters-settings:
   govet:

--- a/README.md
+++ b/README.md
@@ -122,14 +122,13 @@ parser from the tutorial.
 A parser is constructed from a grammar and a lexer:
 
 ```go
-parser, err := participle.Build(&INI{})
+parser, err := participle.Build[INI]()
 ```
 
 Once constructed, the parser is applied to input to produce an AST:
 
 ```go
-ast := &INI{}
-err := parser.ParseString("", "size = 10", ast)
+ast, err := parser.ParseString("", "size = 10")
 // ast == &INI{
 //   Properties: []*Property{
 //     {Key: "size", Value: &Value{Int: &10}},
@@ -282,7 +281,7 @@ now supports this pattern. Simply construct your parser with the `Union[T](membe
 option, eg.
 
 ```go
-parser := participle.MustBuild(&AST{}, participle.Union[Value](Float{}, Int{}, String{}, Bool{}))
+parser := participle.MustBuild[AST](participle.Union[Value](Float{}, Int{}, String{}, Bool{}))
 ```
 
 Custom parsers may also be defined for union types with the [ParseTypeWith](https://pkg.go.dev/github.com/alecthomas/participle/v2#ParseTypeWith) option.
@@ -516,7 +515,7 @@ var (
 		{"Punct", `[-[!@#$%^&*()+_={}\|:;"'<,>.?/]|]`, nil},
 		{"Whitespace", `[ \t\n\r]+`, nil},
 	})
-	parser = participle.MustBuild(&File{},
+	parser = participle.MustBuild[File](
 		participle.Lexer(graphQLLexer),
 		participle.Elide("Comment", "Whitespace"),
 		participle.UseLookahead(2),
@@ -535,10 +534,9 @@ func main() {
 		ctx.Exit(0)
 	}
 	for _, file := range cli.Files {
-		ast := &File{}
 		r, err := os.Open(file)
 		ctx.FatalIfErrorf(err)
-		err = parser.Parse(file, r, ast)
+		ast, err := parser.Parse(file, r)
 		r.Close()
 		repr.Println(ast)
 		ctx.FatalIfErrorf(err)

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -252,21 +252,20 @@ To parse with this grammar we first construct the parser (we'll use the
 default lexer for now):
 
 ```go
-parser, err := participle.Build(&INI{})
+parser, err := participle.Build[INI]()
 ```
 
-Then create a root node and parse into it with `parser.Parse{,String,Bytes}()`:
+Then parse a new INI file with `parser.Parse{,String,Bytes}()`:
 
 ```go
-ini := &INI{}
-err = parser.ParseString("", `
+ini, err := parser.ParseString("", `
 age = 21
 name = "Bob Smith"
 
 [address]
 city = "Beverly Hills"
 postal_code = 90210
-`, ini)
+`)
 ```
 
 You can find the full example [here](_examples/ini/main.go), alongside

--- a/_examples/basic/ast.go
+++ b/_examples/basic/ast.go
@@ -10,8 +10,7 @@ import (
 
 // Parse a BASIC program.
 func Parse(r io.Reader) (*Program, error) {
-	program := &Program{}
-	err := basicParser.Parse("", r, program)
+	program, err := basicParser.Parse("", r)
 	if err != nil {
 		return nil, err
 	}

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -21,7 +21,7 @@ var (
 		{"whitespace", `[ \t]+`},
 	})
 
-	basicParser = participle.MustBuild(&Program{},
+	basicParser = participle.MustBuild[Program](
 		participle.Lexer(basicLexer),
 		participle.CaseInsensitive("Ident"),
 		participle.Unquote("String"),

--- a/_examples/ebnf/main.go
+++ b/_examples/ebnf/main.go
@@ -135,7 +135,7 @@ func (e *EBNF) String() string {
 	return w.String()
 }
 
-var parser = participle.MustBuild(&EBNF{})
+var parser = participle.MustBuild[EBNF]()
 
 func main() {
 	help := `An EBNF parser compatible with Go"s exp/ebnf. The grammar is
@@ -151,8 +151,7 @@ in the form:
 `
 	ctx := kong.Parse(&cli, kong.Description(help))
 
-	ebnf := &EBNF{}
-	err := parser.Parse("", os.Stdin, ebnf)
+	ebnf, err := parser.Parse("", os.Stdin)
 	ctx.FatalIfErrorf(err, "")
 
 	if cli.JSON {

--- a/_examples/ebnf/main_test.go
+++ b/_examples/ebnf/main_test.go
@@ -7,14 +7,13 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	ast := &EBNF{}
-	err := parser.ParseString("", `
+	_, err := parser.ParseString("", `
 Production  = name "=" [ Expression ] "." .
   Expression  = Alternative { "|" Alternative } .
   Alternative = Term { Term } .
   Term        = name | token [ "…" token ] | Group | Option | Repetition .
   Group       = "(" Expression ")" .
   Option      = "[" Expression "]" .
-  Repetition  = "{" Expression "}" .`, ast)
+  Repetition  = "{" Expression "}" .`)
 	require.NoError(t, err)
 }

--- a/_examples/expr/main.go
+++ b/_examples/expr/main.go
@@ -186,7 +186,7 @@ func (e *Expression) Eval(ctx Context) float64 {
 
 type Context map[string]float64
 
-var parser = participle.MustBuild(&Expression{})
+var parser = participle.MustBuild[Expression]()
 
 func main() {
 	ctx := kong.Parse(&cli,
@@ -194,8 +194,7 @@ func main() {
 		kong.UsageOnError(),
 	)
 
-	expr := &Expression{}
-	err := parser.ParseString("", strings.Join(cli.Expression, " "), expr)
+	expr, err := parser.ParseString("", strings.Join(cli.Expression, " "))
 	ctx.FatalIfErrorf(err)
 
 	if cli.AST {

--- a/_examples/expr/main_test.go
+++ b/_examples/expr/main_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	expr := &Expression{}
-	err := parser.ParseString("", `1 + 2 / 3 * (1 + 2)`, expr)
-	require.NoError(t, err)
+	expr, err := parser.ParseString("", `1 + 2 / 3 * (1 + 2)`)
 	repr.Println(expr)
+	require.NoError(t, err)
 }

--- a/_examples/expr2/main.go
+++ b/_examples/expr2/main.go
@@ -63,7 +63,7 @@ type Primary struct {
 	SubExpression *Expression `| "(" @@ ")" `
 }
 
-var parser = participle.MustBuild(&Expression{}, participle.UseLookahead(2))
+var parser = participle.MustBuild[Expression](participle.UseLookahead(2))
 
 func main() {
 	var cli struct {
@@ -71,8 +71,7 @@ func main() {
 	}
 	ctx := kong.Parse(&cli)
 
-	expr := &Expression{}
-	err := parser.ParseString("", strings.Join(cli.Expr, " "), expr)
+	expr, err := parser.ParseString("", strings.Join(cli.Expr, " "))
 	ctx.FatalIfErrorf(err)
 
 	repr.Println(expr)

--- a/_examples/expr2/main_test.go
+++ b/_examples/expr2/main_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	expr := &Expression{}
-	err := parser.ParseString("", `1 + 2 / 3 * (1 + 2)`, expr)
-	require.NoError(t, err)
+	expr, err := parser.ParseString("", `1 + 2 / 3 * (1 + 2)`)
 	repr.Println(expr)
+	require.NoError(t, err)
 }

--- a/_examples/expr3/main.go
+++ b/_examples/expr3/main.go
@@ -104,7 +104,7 @@ type Expression struct {
 	X ExprPrecAll `@@`
 }
 
-var parser = participle.MustBuild(&Expression{},
+var parser = participle.MustBuild[Expression](
 	// This grammar requires enough lookahead to see the entire expression before
 	// it can select the proper binary expression type - in other words, we only
 	// know that `1 * 2 * 3 * 4` isn't the left-hand side of an addition or subtraction
@@ -126,8 +126,7 @@ func main() {
 	}
 	ctx := kong.Parse(&cli)
 
-	expr := &Expression{}
-	err := parser.ParseString("", strings.Join(cli.Expr, " "), expr)
+	expr, err := parser.ParseString("", strings.Join(cli.Expr, " "))
 	ctx.FatalIfErrorf(err)
 
 	repr.Println(expr)

--- a/_examples/expr3/main_test.go
+++ b/_examples/expr3/main_test.go
@@ -42,8 +42,8 @@ func TestExpressionParser(t *testing.T) {
 			},
 		},
 	} {
-		var actual Expression
-		require.NoError(t, parser.ParseString("<test>", c.src, &actual))
+		actual, err := parser.ParseString("<test>", c.src)
+		require.NoError(t, err)
 		require.Equal(t, c.expected, actual.X)
 	}
 }

--- a/_examples/expr4/main.go
+++ b/_examples/expr4/main.go
@@ -120,7 +120,7 @@ type Expression struct {
 	X Expr `@@`
 }
 
-var parser = participle.MustBuild(&Expression{}, participle.ParseTypeWith(parseExprAny))
+var parser = participle.MustBuild[Expression](participle.ParseTypeWith(parseExprAny))
 
 func main() {
 	var cli struct {
@@ -128,8 +128,7 @@ func main() {
 	}
 	ctx := kong.Parse(&cli)
 
-	expr := &Expression{}
-	err := parser.ParseString("", strings.Join(cli.Expr, " "), expr)
+	expr, err := parser.ParseString("", strings.Join(cli.Expr, " "))
 	ctx.FatalIfErrorf(err)
 
 	repr.Println(expr)

--- a/_examples/expr4/main_test.go
+++ b/_examples/expr4/main_test.go
@@ -54,8 +54,8 @@ func TestCustomExprParser(t *testing.T) {
 			},
 		},
 	} {
-		var actual Expression
-		require.NoError(t, parser.ParseString("", c.src, &actual))
+		actual, err := parser.ParseString("", c.src)
+		require.NoError(t, err)
 		require.Equal(t, c.expected, actual.X)
 	}
 }

--- a/_examples/generics/main.go
+++ b/_examples/generics/main.go
@@ -35,16 +35,15 @@ type RHS struct {
 	RHS  *Expr  `@@`
 }
 
-var parser = participle.MustBuild(&Expr{}, participle.UseLookahead(1024))
+var parser = participle.MustBuild[Expr](participle.UseLookahead(1024))
 
 func main() {
-	expr := &Expr{}
-	err := parser.ParseString("", "hello < world * (1 + 3) && (world > 10)", expr)
+	expr, err := parser.ParseString("", "hello < world * (1 + 3) && (world > 10)")
 	if err != nil {
 		panic(err)
 	}
 	repr.Println(expr)
-	err = parser.ParseString("", "type<int, string>.method(1, 2, 3)", expr)
+	expr, err = parser.ParseString("", "type<int, string>.method(1, 2, 3)")
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/graphql/main.go
+++ b/_examples/graphql/main.go
@@ -68,7 +68,7 @@ var (
 		{"Punct", `[-[!@#$%^&*()+_={}\|:;"'<,>.?/]|]`},
 		{"Whitespace", `[ \t\n\r]+`},
 	})
-	parser = participle.MustBuild(&File{},
+	parser = participle.MustBuild[File](
 		participle.Lexer(graphQLLexer),
 		participle.Elide("Comment", "Whitespace"),
 		participle.UseLookahead(2),
@@ -87,10 +87,9 @@ func main() {
 		ctx.Exit(0)
 	}
 	for _, file := range cli.Files {
-		ast := &File{}
 		r, err := os.Open(file)
 		ctx.FatalIfErrorf(err)
-		err = parser.Parse("", r, ast)
+		ast, err := parser.Parse("", r)
 		r.Close()
 		repr.Println(ast)
 		ctx.FatalIfErrorf(err)

--- a/_examples/graphql/main_test.go
+++ b/_examples/graphql/main_test.go
@@ -13,7 +13,6 @@ func BenchmarkParser(b *testing.B) {
 	b.ReportAllocs()
 	b.ReportMetric(float64(len(source)*b.N), "B/s")
 	for i := 0; i < b.N; i++ {
-		ast := &File{}
-		_ = parser.ParseBytes("", source, ast)
+		_, _ = parser.ParseBytes("", source)
 	}
 }

--- a/_examples/hcl/main.go
+++ b/_examples/hcl/main.go
@@ -58,11 +58,10 @@ type Config struct {
 	Entries []*Entry `@@*`
 }
 
-var parser = participle.MustBuild(&Config{}, participle.Unquote())
+var parser = participle.MustBuild[Config](participle.Unquote())
 
 func main() {
-	expr := &Config{}
-	err := parser.Parse("", os.Stdin, expr)
+	expr, err := parser.Parse("", os.Stdin)
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/hcl/main_test.go
+++ b/_examples/hcl/main_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	ast := &Config{}
-	err := parser.ParseString("", `
+	ast, err := parser.ParseString("", `
 region = "us-west-2"
 access_key = "something"
 secret_key = "something_else"
@@ -35,7 +34,7 @@ directory data {
     pre_restore_script = "before_restore.sh"
     post_restore_script = "after_restore.sh"
 }
-`, ast)
-	require.NoError(t, err)
+`)
 	repr.Println(ast)
+	require.NoError(t, err)
 }

--- a/_examples/ini/main.go
+++ b/_examples/ini/main.go
@@ -20,7 +20,7 @@ var (
 		{"comment", `[#;][^\n]*`},
 		{"whitespace", `\s+`},
 	})
-	parser = participle.MustBuild(&INI{},
+	parser = participle.MustBuild[INI](
 		participle.Lexer(iniLexer),
 		participle.Unquote("String"),
 		participle.Union[Value](String{}, Number{}),
@@ -57,10 +57,9 @@ type Number struct {
 func (Number) value() {}
 
 func main() {
-	ini := &INI{}
-	err := parser.Parse("", os.Stdin, ini)
+	ini, err := parser.Parse("", os.Stdin)
+	repr.Println(ini, repr.Indent("  "), repr.OmitEmpty(true))
 	if err != nil {
 		panic(err)
 	}
-	repr.Println(ini, repr.Indent("  "), repr.OmitEmpty(true))
 }

--- a/_examples/ini/main_test.go
+++ b/_examples/ini/main_test.go
@@ -8,13 +8,12 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	ini := &INI{}
-	err := parser.ParseString("", `
+	ini, err := parser.ParseString("", `
 global = 1
 
 [section]
 value = "str"
-`, ini)
+`)
 	require.NoError(t, err)
 	repr.Println(ini)
 }

--- a/_examples/jsonpath/main.go
+++ b/_examples/jsonpath/main.go
@@ -22,7 +22,7 @@ type acc struct {
 	Index *int    `| @Int`
 }
 
-var parser = participle.MustBuild(&pathExpr{})
+var parser = participle.MustBuild[pathExpr]()
 
 func main() {
 	if len(os.Args) < 3 {
@@ -33,8 +33,8 @@ func main() {
 	q := os.Args[1]
 	files := os.Args[2:]
 
-	var expr pathExpr
-	if err := parser.ParseString("", q, &expr); err != nil {
+	expr, err := parser.ParseString("", q)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -71,7 +71,7 @@ func main() {
 	}
 }
 
-func match(input map[string]interface{}, expr pathExpr) (interface{}, error) {
+func match(input map[string]interface{}, expr *pathExpr) (interface{}, error) {
 	var v interface{} = input
 	for _, e := range expr.Parts {
 		switch m := v.(type) {

--- a/_examples/jsonpath/main_test.go
+++ b/_examples/jsonpath/main_test.go
@@ -15,8 +15,7 @@ func TestExe(t *testing.T) {
 	err = json.NewDecoder(r).Decode(&input)
 	require.NoError(t, err)
 
-	ast := pathExpr{}
-	err = parser.ParseString(``, `check_run.check_suite.pull_requests[0].url`, &ast)
+	ast, err := parser.ParseString(``, `check_run.check_suite.pull_requests[0].url`)
 	require.NoError(t, err)
 
 	result, err := match(input, ast)

--- a/_examples/microc/main.go
+++ b/_examples/microc/main.go
@@ -236,7 +236,7 @@ var (
 		{"Punct", `[-,()*/+%{};&!=:<>]|\[|\]`},
 		{"Int", `\d+`},
 	})
-	parser = participle.MustBuild(&Program{},
+	parser = participle.MustBuild[Program](
 		participle.Lexer(lex),
 		participle.UseLookahead(2))
 )
@@ -278,11 +278,8 @@ int main(void)
 `
 
 func main() {
-	ast := &Program{}
-	defer func() {
-		repr.Println(ast)
-	}()
-	err := parser.ParseString("", sample, ast)
+	ast, err := parser.ParseString("", sample)
+	repr.Println(ast)
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/microc/main_test.go
+++ b/_examples/microc/main_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	program := &Program{}
-	err := parser.ParseString("", sample, program)
+	program, err := parser.ParseString("", sample)
 	require.NoError(t, err)
 	repr.Println(program)
 }
@@ -20,7 +19,6 @@ func BenchmarkParser(b *testing.B) {
 	b.ReportAllocs()
 	b.ReportMetric(float64(len(src)*b.N), "B/s")
 	for i := 0; i < b.N; i++ {
-		program := &Program{}
-		_ = parser.ParseString("", src, program)
+		_, _ = parser.ParseString("", src)
 	}
 }

--- a/_examples/precedenceclimbing/main.go
+++ b/_examples/precedenceclimbing/main.go
@@ -115,14 +115,13 @@ func parseOp(op string, lhs *Expr, rhs *Expr) *Expr {
 	}
 }
 
-var parser = participle.MustBuild(&Expr{})
+var parser = participle.MustBuild[Expr]()
 
 func main() {
-	e := &Expr{}
-	err := parser.ParseString("", strings.Join(os.Args[1:], " "), e)
+	e, err := parser.ParseString("", strings.Join(os.Args[1:], " "))
+	fmt.Println(e)
+	repr.Println(e)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(e)
-	repr.Println(e)
 }

--- a/_examples/precedenceclimbing/main_test.go
+++ b/_examples/precedenceclimbing/main_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	actual := &Expr{}
-	err := parser.ParseString("", `1 + 2 - 3 * (4 + 2)`, actual)
+	actual, err := parser.ParseString("", `1 + 2 - 3 * (4 + 2)`)
 	require.NoError(t, err)
 	expected := expr(
 		expr(intp(1), "+", intp(2)),

--- a/_examples/protobuf/main.go
+++ b/_examples/protobuf/main.go
@@ -254,7 +254,7 @@ type MapType struct {
 }
 
 var (
-	parser = participle.MustBuild(&Proto{}, participle.UseLookahead(2))
+	parser = participle.MustBuild[Proto](participle.UseLookahead(2))
 
 	cli struct {
 		Files []string `required existingfile arg help:"Protobuf files."`
@@ -266,10 +266,9 @@ func main() {
 
 	for _, file := range cli.Files {
 		fmt.Println(file)
-		proto := &Proto{}
 		r, err := os.Open(file)
 		ctx.FatalIfErrorf(err, "")
-		err = parser.Parse("", r, proto)
+		proto, err := parser.Parse("", r)
 		ctx.FatalIfErrorf(err, "")
 		repr.Println(proto, repr.Hide(&lexer.Position{}))
 	}

--- a/_examples/protobuf/main_test.go
+++ b/_examples/protobuf/main_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	ast := &Proto{}
-	err := parser.ParseString("", `
+	_, err := parser.ParseString("", `
 syntax = "proto3";
 
 package test.test;
@@ -38,6 +37,6 @@ enum Type {
 service SearchService {
   rpc Search(SearchRequest) returns (SearchResponse);
 }
-`, ast)
+`)
 	require.NoError(t, err)
 }

--- a/_examples/simpleexpr/main.go
+++ b/_examples/simpleexpr/main.go
@@ -29,7 +29,7 @@ var (
 	cli struct {
 		Expr string `arg:"" help:"Expression."`
 	}
-	parser = participle.MustBuild(&Expr{})
+	parser = participle.MustBuild[Expr]()
 )
 
 func main() {
@@ -42,8 +42,7 @@ the parser, is that it is significantly less complex and less nested. The
 advantage of this over the "precedenceclimbing" example is that no custom
 parsing is required.
 `))
-	expr := &Expr{}
-	err := parser.ParseString("", cli.Expr, expr)
+	expr, err := parser.ParseString("", cli.Expr)
 	kctx.FatalIfErrorf(err)
 	repr.Println(expr)
 }

--- a/_examples/simpleexpr/main_test.go
+++ b/_examples/simpleexpr/main_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	expr := &Expr{}
-	err := parser.ParseString("", `1 + 2 / 3 * (1 + 2)`, expr)
-	require.NoError(t, err)
+	expr, err := parser.ParseString("", `1 + 2 / 3 * (1 + 2)`)
 	repr.Println(expr)
+	require.NoError(t, err)
 }

--- a/_examples/sql/main.go
+++ b/_examples/sql/main.go
@@ -166,8 +166,7 @@ var (
 		{`Operators`, `<>|!=|<=|>=|[-+*/%,.()=<>]`},
 		{"whitespace", `\s+`},
 	})
-	parser = participle.MustBuild(
-		&Select{},
+	parser = participle.MustBuild[Select](
 		participle.Lexer(sqlLexer),
 		participle.Unquote("String"),
 		participle.CaseInsensitive("Keyword"),
@@ -179,8 +178,7 @@ var (
 
 func main() {
 	ctx := kong.Parse(&cli)
-	sql := &Select{}
-	err := parser.ParseString("", cli.SQL, sql)
+	sql, err := parser.ParseString("", cli.SQL)
 	repr.Println(sql, repr.Indent("  "), repr.OmitEmpty(true))
 	ctx.FatalIfErrorf(err)
 }

--- a/_examples/sql/main_test.go
+++ b/_examples/sql/main_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	sel := &Select{}
-	err := parser.ParseString("", `SELECT * FROM table WHERE attr = 10`, sel)
+	sel, err := parser.ParseString("", `SELECT * FROM table WHERE attr = 10`)
 	require.NoError(t, err)
 	repr.Println(sel)
 }

--- a/_examples/stateful/main.go
+++ b/_examples/stateful/main.go
@@ -49,15 +49,14 @@ var (
 			{"ExprEnd", `}`, lexer.Pop()},
 		},
 	})
-	parser = participle.MustBuild(&String{}, participle.Lexer(def),
+	parser = participle.MustBuild[String](participle.Lexer(def),
 		participle.Elide("Whitespace"))
 )
 
 func main() {
-	actual := &String{}
-	err := parser.ParseString("", `"hello $(world) ${first + "${last}"}"`, actual)
+	actual, err := parser.ParseString("", `"hello $(world) ${first + "${last}"}"`)
+	repr.Println(actual)
 	if err != nil {
 		log.Fatal(err)
 	}
-	repr.Println(actual)
 }

--- a/_examples/stateful/main_test.go
+++ b/_examples/stateful/main_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	actual := &String{}
-	err := parser.ParseString("", `"hello $(world) ${first + "${last}"}"`, actual)
+	actual, err := parser.ParseString("", `"hello $(world) ${first + "${last}"}"`)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/_examples/thrift/main.go
+++ b/_examples/thrift/main.go
@@ -200,7 +200,7 @@ var (
 		{"Punct", `[,.<>(){}=:]`},
 		{"Comment", `//.*`},
 	})
-	parser = participle.MustBuild(&Thrift{},
+	parser = participle.MustBuild[Thrift](
 		participle.Lexer(def),
 		participle.Unquote(),
 		participle.Elide("Whitespace"),
@@ -225,10 +225,9 @@ func main() {
 	}
 
 	for _, file := range cli.Files {
-		thrift := &Thrift{}
 		r, err := os.Open(file)
 		ctx.FatalIfErrorf(err, "")
-		err = parser.Parse("", r, thrift)
+		thrift, err := parser.Parse("", r)
 		ctx.FatalIfErrorf(err, "")
 		repr.Println(thrift)
 	}

--- a/_examples/thrift/main_test.go
+++ b/_examples/thrift/main_test.go
@@ -58,8 +58,7 @@ service Twitter {
 )
 
 func BenchmarkParticipleThrift(b *testing.B) {
-	thrift := &Thrift{}
-	err := parser.ParseString("", source, thrift)
+	_, err := parser.ParseString("", source)
 	require.NoError(b, err)
 
 	b.ResetTimer()
@@ -67,21 +66,19 @@ func BenchmarkParticipleThrift(b *testing.B) {
 
 	start := time.Now()
 	for i := 0; i < b.N; i++ {
-		thrift := &Thrift{}
-		_ = parser.ParseString("", source, thrift)
+		_, _ = parser.ParseString("", source)
 	}
 	b.ReportMetric(float64(len(source)*b.N)*float64(time.Since(start)/time.Second)/1024/1024, "MiB/s")
 }
 
 func BenchmarkParticipleThriftGenerated(b *testing.B) {
-	parser := participle.MustBuild(&Thrift{},
+	parser := participle.MustBuild[Thrift](
 		participle.Lexer(Lexer),
 		participle.Unquote(),
 		participle.Elide("Whitespace"),
 	)
 
-	thrift := &Thrift{}
-	err := parser.ParseString("", source, thrift)
+	_, err := parser.ParseString("", source)
 	require.NoError(b, err)
 
 	b.ResetTimer()
@@ -89,8 +86,7 @@ func BenchmarkParticipleThriftGenerated(b *testing.B) {
 
 	start := time.Now()
 	for i := 0; i < b.N; i++ {
-		thrift := &Thrift{}
-		_ = parser.ParseString("", source, thrift)
+		_, _ = parser.ParseString("", source)
 	}
 	b.ReportMetric(float64(len(source)*b.N)*float64(time.Since(start)/time.Second)/1024/1024, "MiB/s")
 }

--- a/_examples/toml/main.go
+++ b/_examples/toml/main.go
@@ -54,10 +54,8 @@ var (
 		{"comment", `#[^\n]+`},
 		{"whitespace", `\s+`},
 	})
-	tomlParser = participle.MustBuild(&TOML{},
-		participle.Lexer(
-			tomlLexer,
-		),
+	tomlParser = participle.MustBuild[TOML](
+		participle.Lexer(tomlLexer),
 		participle.Unquote("String"),
 	)
 
@@ -68,11 +66,10 @@ var (
 
 func main() {
 	ctx := kong.Parse(&cli)
-	toml := &TOML{}
 	r, err := os.Open(cli.File)
 	ctx.FatalIfErrorf(err)
 	defer r.Close()
-	err = tomlParser.Parse(cli.File, r, toml)
+	toml, err := tomlParser.Parse(cli.File, r)
 	ctx.FatalIfErrorf(err)
 	repr.Println(toml)
 }

--- a/_examples/toml/main_test.go
+++ b/_examples/toml/main_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestExe(t *testing.T) {
-	toml := &TOML{}
-	err := tomlParser.ParseString("", `
+	toml, err := tomlParser.ParseString("", `
 # This is a TOML document.
 
 title = "TOML Example"
@@ -44,7 +43,7 @@ hosts = [
   "alpha",
   "omega"
 ]
-`, toml)
+`)
 	require.NoError(t, err)
 	repr.Println(toml)
 }

--- a/ebnf.go
+++ b/ebnf.go
@@ -8,7 +8,7 @@ import (
 // String returns the EBNF for the grammar.
 //
 // Productions are always upper cased. Lexer tokens are always lower case.
-func (p *Parser) String() string {
+func (p *Parser[G]) String() string {
 	return ebnf(p.typeNodes[p.rootType])
 }
 

--- a/ebnf/ebnf.go
+++ b/ebnf/ebnf.go
@@ -17,7 +17,7 @@ import (
 	"github.com/alecthomas/participle/v2"
 )
 
-var parser = participle.MustBuild(&EBNF{})
+var parser = participle.MustBuild[EBNF]()
 
 // A Node in the EBNF grammar.
 type Node interface {
@@ -167,12 +167,10 @@ func (e *EBNF) String() (out string) {
 
 // ParseString string into EBNF.
 func ParseString(ebnf string) (*EBNF, error) {
-	out := &EBNF{}
-	return out, parser.ParseString("", ebnf, out)
+	return parser.ParseString("", ebnf)
 }
 
 // Parse io.Reader into EBNF.
 func Parse(r io.Reader) (*EBNF, error) {
-	out := &EBNF{}
-	return out, parser.Parse("", r, out)
+	return parser.Parse("", r)
 }

--- a/ebnf_test.go
+++ b/ebnf_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEBNF(t *testing.T) {
-	parser := mustTestParser(t, &EBNF{})
+	parser := mustTestParser[EBNF](t)
 	expected := `
 EBNF = Production* .
 Production = <ident> "=" Expression+ "." .
@@ -34,7 +34,7 @@ func TestEBNF_Other(t *testing.T) {
 		Negation          string `| !("anything" | 'but')`
 	}
 
-	parser := mustTestParser(t, &Grammar{})
+	parser := mustTestParser[Grammar](t)
 	expected := `Grammar = ((?= "good") <ident>) | ((?! "bad" | "worse") <ident>) | ~("anything" | "but") .`
 	require.Equal(t, expected, parser.String())
 }
@@ -64,7 +64,7 @@ func TestEBNF_Union(t *testing.T) {
 		TheUnion EBNFUnion `@@`
 	}
 
-	parser := mustTestParser(t, &Grammar{}, participle.Union[EBNFUnion](EBNFUnionA{}, EBNFUnionB{}, EBNFUnionC{}))
+	parser := mustTestParser[Grammar](t, participle.Union[EBNFUnion](EBNFUnionA{}, EBNFUnionB{}, EBNFUnionC{}))
 	require.Equal(t,
 		strings.TrimSpace(`
 Grammar = EBNFUnion .

--- a/error_test.go
+++ b/error_test.go
@@ -25,20 +25,18 @@ func TestErrorReporting(t *testing.T) {
 	type grammar struct {
 		Decls []*decl `( @@ ";" )*`
 	}
-	p := mustTestParser(t, &grammar{}, participle.UseLookahead(5))
+	p := mustTestParser[grammar](t, participle.UseLookahead(5))
 
-	var err error
-	ast := &grammar{}
-	err = p.ParseString("", `public class A;`, ast)
+	ast, err := p.ParseString("", `public class A;`)
 	require.NoError(t, err)
 	require.Equal(t, &grammar{Decls: []*decl{
 		{Class: &cls{Visibility: "public", Class: "A"}},
 	}}, ast)
-	err = p.ParseString("", `public union A;`, ast)
+	_, err = p.ParseString("", `public union A;`)
 	require.NoError(t, err)
-	err = p.ParseString("", `public struct Bar;`, ast)
+	_, err = p.ParseString("", `public struct Bar;`)
 	require.EqualError(t, err, `1:8: unexpected token "struct" (expected "union" <ident>)`)
-	err = p.ParseString("", `public class 1;`, ast)
+	_, err = p.ParseString("", `public class 1;`)
 	require.EqualError(t, err, `1:14: unexpected token "1" (expected <ident>)`)
 }
 

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -11,7 +11,7 @@ func TestBuild_Errors_Negation(t *testing.T) {
 	type grammar struct {
 		Whatever string `'a' | ! | 'b'`
 	}
-	_, err := participle.Build(&grammar{})
+	_, err := participle.Build[grammar]()
 	require.EqualError(t, err, "Whatever: unexpected token |")
 }
 
@@ -19,7 +19,7 @@ func TestBuild_Errors_Capture(t *testing.T) {
 	type grammar struct {
 		Whatever string `'a' | @ | 'b'`
 	}
-	_, err := participle.Build(&grammar{})
+	_, err := participle.Build[grammar]()
 	require.EqualError(t, err, "Whatever: unexpected token |")
 }
 
@@ -27,7 +27,7 @@ func TestBuild_Errors_UnclosedGroup(t *testing.T) {
 	type grammar struct {
 		Whatever string `'a' | ('b' | 'c'`
 	}
-	_, err := participle.Build(&grammar{})
+	_, err := participle.Build[grammar]()
 	require.EqualError(t, err, `Whatever: expected ) but got "<EOF>"`)
 }
 
@@ -35,7 +35,7 @@ func TestBuild_Errors_LookaheadGroup(t *testing.T) {
 	type grammar struct {
 		Whatever string `'a' | (?? 'what') | 'b'`
 	}
-	_, err := participle.Build(&grammar{})
+	_, err := participle.Build[grammar]()
 	require.EqualError(t, err, `Whatever: expected = or ! but got "?"`)
 }
 
@@ -46,7 +46,7 @@ func TestBuild_Colon_OK(t *testing.T) {
 		SinglePresent bool   `| 'SinglePresent' ':'  Ident`
 		SingleCapture string `| 'SingleCapture' ':' @Ident`
 	}
-	parser, err := participle.Build(&grammar{})
+	parser, err := participle.Build[grammar]()
 	require.NoError(t, err)
 	require.Equal(t, `Grammar = "TokenTypeTest"`+
 		` | ("DoubleCapture" ":" <ident>)`+
@@ -58,6 +58,6 @@ func TestBuild_Colon_MissingTokenType(t *testing.T) {
 	type grammar struct {
 		Key string `'name' : @Ident`
 	}
-	_, err := participle.Build(&grammar{})
+	_, err := participle.Build[grammar]()
 	require.EqualError(t, err, `Key: expected identifier for literal type constraint but got "@"`)
 }

--- a/lexer/stateful_test.go
+++ b/lexer/stateful_test.go
@@ -230,13 +230,12 @@ func ExampleNew() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	parser, err := participle.Build(&String{}, participle.Lexer(def))
+	parser, err := participle.Build[String](participle.Lexer(def))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	actual := &String{}
-	err = parser.ParseString("", `"hello ${user + "??"}"`, actual)
+	actual, err := parser.ParseString("", `"hello ${user + "??"}"`)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -284,11 +283,10 @@ func TestStateful(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	parser, err := participle.Build(&String{}, participle.Lexer(def))
+	parser, err := participle.Build[String](participle.Lexer(def))
 	require.NoError(t, err)
 
-	actual := &String{}
-	err = parser.ParseString("", `"hello ${user + "${last}"}"`, actual)
+	actual, err := parser.ParseString("", `"hello ${user + "${last}"}"`)
 	require.NoError(t, err)
 	expected := &String{
 		Fragments: []*Fragment{
@@ -335,9 +333,7 @@ func TestHereDoc(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	parser, err := participle.Build(&AST{},
-		participle.Lexer(def),
-	)
+	parser, err := participle.Build[AST](participle.Lexer(def))
 	require.NoError(t, err)
 
 	expected := &AST{
@@ -345,12 +341,11 @@ func TestHereDoc(t *testing.T) {
 			Idents: []string{"hello", "world"},
 		},
 	}
-	actual := &AST{}
-	err = parser.ParseString("", `
+	actual, err := parser.ParseString("", `
 		<<END
 		hello world
 		END
-	`, actual)
+	`)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 }

--- a/lexer/text_scanner_test.go
+++ b/lexer/text_scanner_test.go
@@ -47,10 +47,9 @@ func TestNewTextScannerLexerDefault(t *testing.T) {
 	type grammar struct {
 		Text string `@String @Ident`
 	}
-	p, err := participle.Build(&grammar{}, participle.Lexer(lexer.NewTextScannerLexer(nil)), participle.Unquote())
+	p, err := participle.Build[grammar](participle.Lexer(lexer.NewTextScannerLexer(nil)), participle.Unquote())
 	require.NoError(t, err)
-	g := &grammar{}
-	err = p.ParseString("", `"hello" world`, g)
+	g, err := p.ParseString("", `"hello" world`)
 	require.NoError(t, err)
 	require.Equal(t, "helloworld", g.Text)
 }
@@ -59,12 +58,11 @@ func TestNewTextScannerLexer(t *testing.T) {
 	type grammar struct {
 		Text string `(@String | @Comment | @Ident)+`
 	}
-	p, err := participle.Build(&grammar{}, participle.Lexer(lexer.NewTextScannerLexer(func(s *scanner.Scanner) {
+	p, err := participle.Build[grammar](participle.Lexer(lexer.NewTextScannerLexer(func(s *scanner.Scanner) {
 		s.Mode &^= scanner.SkipComments
 	})), participle.Unquote())
 	require.NoError(t, err)
-	g := &grammar{}
-	err = p.ParseString("", `"hello" /* comment */ world`, g)
+	g, err := p.ParseString("", `"hello" /* comment */ world`)
 	require.NoError(t, err)
 	require.Equal(t, "hello/* comment */world", g.Text)
 }

--- a/map.go
+++ b/map.go
@@ -22,7 +22,7 @@ type Mapper func(token lexer.Token) (lexer.Token, error)
 //
 // "symbols" specifies the token symbols that the Mapper will be applied to. If empty, all tokens will be mapped.
 func Map(mapper Mapper, symbols ...string) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		p.mappers = append(p.mappers, mapperByToken{
 			mapper:  mapper,
 			symbols: symbols,
@@ -73,7 +73,7 @@ func Upper(types ...string) Option {
 
 // Elide drops tokens of the specified types.
 func Elide(types ...string) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		p.elide = append(p.elide, types...)
 		return nil
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestUpper(t *testing.T) {
-	var grammar struct {
+	type grammar struct {
 		Text string `@Ident`
 	}
 	def := lexer.MustSimple([]lexer.SimpleRule{
 		{"Whitespace", `\s+`},
 		{"Ident", `\w+`},
 	})
-	parser := mustTestParser(t, &grammar, participle.Lexer(def), participle.Upper("Ident"))
+	parser := mustTestParser[grammar](t, participle.Lexer(def), participle.Upper("Ident"))
 	actual, err := parser.Lex("", strings.NewReader("hello world"))
 	require.NoError(t, err)
 
@@ -32,7 +32,7 @@ func TestUpper(t *testing.T) {
 }
 
 func TestUnquote(t *testing.T) {
-	var grammar struct {
+	type grammar struct {
 		Text string `@Ident`
 	}
 	lex := lexer.MustSimple([]lexer.SimpleRule{
@@ -41,7 +41,7 @@ func TestUnquote(t *testing.T) {
 		{"String", `\"(?:[^\"]|\\.)*\"`},
 		{"RawString", "`[^`]*`"},
 	})
-	parser := mustTestParser(t, &grammar, participle.Lexer(lex), participle.Unquote("String", "RawString"))
+	parser := mustTestParser[grammar](t, participle.Lexer(lex), participle.Unquote("String", "RawString"))
 	actual, err := parser.Lex("", strings.NewReader("hello world \"quoted\\tstring\" `backtick quotes`"))
 	require.NoError(t, err)
 	expected := []lexer.Token{

--- a/options.go
+++ b/options.go
@@ -14,11 +14,11 @@ import (
 const MaxLookahead = 99999
 
 // An Option to modify the behaviour of the Parser.
-type Option func(p *Parser) error
+type Option func(p *parserOptions) error
 
 // Lexer is an Option that sets the lexer to use with the given grammar.
 func Lexer(def lexer.Definition) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		p.lex = def
 		return nil
 	}
@@ -39,7 +39,7 @@ func Lexer(def lexer.Definition) Option {
 // Using infinite lookahead can be useful for testing, or for parsing especially
 // ambiguous grammars. Use at your own risk!
 func UseLookahead(n int) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		p.useLookahead = n
 		return nil
 	}
@@ -50,7 +50,7 @@ func UseLookahead(n int) Option {
 // Note that the lexer itself will also have to be case-insensitive; this option
 // just controls whether literals in the grammar are matched case insensitively.
 func CaseInsensitive(tokens ...string) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		for _, token := range tokens {
 			p.caseInsensitive[token] = true
 		}
@@ -70,7 +70,7 @@ func CaseInsensitive(tokens ...string) Option {
 // This can be useful if you want to parse a DSL within the larger grammar, or if you want
 // to implement an optimized parsing scheme for some portion of the grammar.
 func ParseTypeWith[T any](parseFn func(*lexer.PeekingLexer) (T, error)) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		parseFnVal := reflect.ValueOf(parseFn)
 		parseFnType := parseFnVal.Type()
 		if parseFnType.Out(0).Kind() != reflect.Interface {
@@ -95,7 +95,7 @@ func ParseTypeWith[T any](parseFn func(*lexer.PeekingLexer) (T, error)) Option {
 // and the source string is "AB", then the parser will only match A, and will not
 // try to parse the second member at all.
 func Union[T any](members ...T) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		unionType := reflect.TypeOf((*T)(nil)).Elem()
 		if unionType.Kind() != reflect.Interface {
 			return fmt.Errorf("Union: union type must be an interface (got %s)", unionType)

--- a/validate_test.go
+++ b/validate_test.go
@@ -13,7 +13,7 @@ type leftRecursionSimple struct {
 }
 
 func TestValidateLeftRecursion(t *testing.T) {
-	_, err := participle.Build(&leftRecursionSimple{})
+	_, err := participle.Build[leftRecursionSimple]()
 	require.Error(t, err)
 	require.Equal(t, err.Error(), `left recursion detected on
 
@@ -31,7 +31,7 @@ type leftRecursionNested struct {
 }
 
 func TestValidateLeftRecursionNested(t *testing.T) {
-	_, err := participle.Build(&leftRecursionNested{})
+	_, err := participle.Build[leftRecursionNested]()
 	require.Error(t, err)
 	require.Equal(t, err.Error(), `left recursion detected on
 


### PR DESCRIPTION
`Build(&Grammar{})` becomes `Build[Grammar]()` and
`err = parser.Parse(filename, &grammar)` becomes
`grammar, err := parser.Parse(filename)`.