### PR TITLE
Peeking lexer optimizations

### DIFF
--- a/context.go
+++ b/context.go
@@ -18,7 +18,7 @@ type contextFieldSet struct {
 
 // Context for a single parse.
 type parseContext struct {
-	*lexer.PeekingLexer
+	lexer.PeekingLexer
 	depth             int
 	trace             io.Writer
 	deepestError      error
@@ -31,7 +31,7 @@ type parseContext struct {
 
 func newParseContext(lex *lexer.PeekingLexer, lookahead int, caseInsensitive map[lexer.TokenType]bool) *parseContext {
 	return &parseContext{
-		PeekingLexer:    lex,
+		PeekingLexer:    *lex,
 		caseInsensitive: caseInsensitive,
 		lookahead:       lookahead,
 	}
@@ -78,7 +78,6 @@ func (p *parseContext) Branch() *parseContext {
 	branch := &parseContext{}
 	*branch = *p
 	branch.apply = nil
-	branch.PeekingLexer = p.PeekingLexer.Clone()
 	return branch
 }
 

--- a/lexer/peek.go
+++ b/lexer/peek.go
@@ -13,7 +13,7 @@ type RawCursor int
 
 // Checkpoint wraps the mutable state of the PeekingLexer.
 //
-// Copying and restoring this state provides an allocation-free alternative to PeekingLexer.Clone.
+// Copying and restoring just this state is a bit faster than copying the entire PeekingLexer.
 type Checkpoint struct {
 	rawCursor RawCursor
 	cursor    int
@@ -122,12 +122,4 @@ func (p *PeekingLexer) RawPeek() *Token {
 		return &p.tokens[p.rawCursor]
 	}
 	return &p.eof
-}
-
-// Clone creates a clone of this PeekingLexer at its current token.
-//
-// The parent and clone are completely independent.
-func (p *PeekingLexer) Clone() *PeekingLexer {
-	clone := *p
-	return &clone
 }

--- a/lexer/peek.go
+++ b/lexer/peek.go
@@ -2,15 +2,22 @@ package lexer
 
 // PeekingLexer supports arbitrary lookahead as well as cloning.
 type PeekingLexer struct {
-	rawCursor RawCursor
-	cursor    int
-	eof       Token
-	tokens    []Token
-	elide     map[TokenType]bool
+	Checkpoint
+	eof    Token
+	tokens []Token
+	elide  map[TokenType]bool
 }
 
 // RawCursor index in the token stream.
 type RawCursor int
+
+// Checkpoint wraps the mutable state of the PeekingLexer.
+//
+// Copying and restoring this state provides an allocation-free alternative to PeekingLexer.Clone.
+type Checkpoint struct {
+	rawCursor RawCursor
+	cursor    int
+}
 
 // Upgrade a Lexer to a PeekingLexer with arbitrary lookahead.
 //
@@ -42,13 +49,13 @@ func (p *PeekingLexer) Range(rawStart, rawEnd RawCursor) []Token {
 }
 
 // Cursor position in tokens, excluding elided tokens.
-func (p *PeekingLexer) Cursor() int {
-	return p.cursor
+func (c Checkpoint) Cursor() int {
+	return c.cursor
 }
 
 // RawCursor position in tokens, including elided tokens.
-func (p *PeekingLexer) RawCursor() RawCursor {
-	return p.rawCursor
+func (c Checkpoint) RawCursor() RawCursor {
+	return c.rawCursor
 }
 
 // Next consumes and returns the next token.

--- a/lexer/peek.go
+++ b/lexer/peek.go
@@ -123,3 +123,11 @@ func (p *PeekingLexer) FastForward(rawCursor RawCursor) {
 	p.nextCursor = p.rawCursor
 	p.advanceToNonElided()
 }
+
+func (p *PeekingLexer) MakeCheckpoint() Checkpoint {
+	return p.Checkpoint
+}
+
+func (p *PeekingLexer) LoadCheckpoint(checkpoint Checkpoint) {
+	p.Checkpoint = checkpoint
+}

--- a/lexer/peek_test.go
+++ b/lexer/peek_test.go
@@ -55,3 +55,19 @@ func TestPeekingLexer_Peek_Next_Checkpoint(t *testing.T) {
 	plex.Checkpoint = checkpoint
 	require.Equal(t, expected[0], *plex.Peek(), "should have reverted to pre-Next state")
 }
+
+func BenchmarkPeekingLexer_Peek(b *testing.B) {
+	tokens := []lexer.Token{{Type: 1, Value: "x"}, {Type: 3, Value: " "}, {Type: 2, Value: "y"}}
+	l, err := lexer.Upgrade(&staticLexer{tokens: tokens}, 3)
+	require.NoError(b, err)
+	l.Next()
+	t := l.Peek()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t = l.Peek()
+		if t.EOF() {
+			return
+		}
+	}
+	require.Equal(b, lexer.Token{Type: 2, Value: "y"}, *t)
+}

--- a/lexer/peek_test.go
+++ b/lexer/peek_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	require "github.com/alecthomas/assert/v2"
+
 	"github.com/alecthomas/participle/v2/lexer"
 )
 
@@ -32,7 +33,7 @@ func TestUpgrade(t *testing.T) {
 	require.Equal(t, tokens, l.Range(0, 3))
 }
 
-func TestPeekAndNextAny(t *testing.T) {
+func TestPeekingLexer_Peek_Next_Checkpoint(t *testing.T) {
 	slexdef := lexer.MustSimple([]lexer.SimpleRule{
 		{"Ident", `\w+`},
 		{"Whitespace", `\s+`},
@@ -48,7 +49,9 @@ func TestPeekAndNextAny(t *testing.T) {
 		{Type: -3, Value: " ", Pos: lexer.Position{Line: 1, Column: 12, Offset: 11}},
 		{Type: -2, Value: "last", Pos: lexer.Position{Line: 1, Column: 13, Offset: 12}},
 	}
-	tok := plex.Next()
-	require.Equal(t, expected[0], *tok)
+	checkpoint := plex.Checkpoint
+	require.Equal(t, expected[0], *plex.Next())
 	require.Equal(t, expected[2], *plex.Peek(), "should have skipped whitespace")
+	plex.Checkpoint = checkpoint
+	require.Equal(t, expected[0], *plex.Peek(), "should have reverted to pre-Next state")
 }

--- a/nodes.go
+++ b/nodes.go
@@ -63,7 +63,7 @@ func (p *parseable) Parse(ctx *parseContext, parent reflect.Value) (out []reflec
 	defer ctx.printTrace(p)()
 	rv := reflect.New(p.t)
 	v := rv.Interface().(Parseable)
-	err = v.Parse(ctx.PeekingLexer)
+	err = v.Parse(&ctx.PeekingLexer)
 	if err != nil {
 		if err == NextMatch {
 			return nil, nil
@@ -84,7 +84,7 @@ func (c *custom) GoString() string { return c.typ.Name() }
 
 func (c *custom) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.Value, err error) {
 	defer ctx.printTrace(c)()
-	results := c.parseFn.Call([]reflect.Value{reflect.ValueOf(ctx.PeekingLexer)})
+	results := c.parseFn.Call([]reflect.Value{reflect.ValueOf(&ctx.PeekingLexer)})
 	if err, _ := results[1].Interface().(error); err != nil {
 		if err == NextMatch {
 			return nil, nil

--- a/parser.go
+++ b/parser.go
@@ -169,7 +169,7 @@ func (p *Parser[G]) ParseFromLexer(lex *lexer.PeekingLexer, options ...ParseOpti
 		}
 	}
 	ctx := newParseContext(lex, p.useLookahead, caseInsensitive)
-	defer func() { *lex = *ctx.PeekingLexer }()
+	defer func() { *lex = ctx.PeekingLexer }()
 	for _, option := range options {
 		option(ctx)
 	}
@@ -268,7 +268,7 @@ func (p *Parser[G]) parseInto(ctx *parseContext, parseNode node, rv reflect.Valu
 }
 
 func (p *Parser[G]) rootParseable(ctx *parseContext, parseable Parseable) error {
-	if err := parseable.Parse(ctx.PeekingLexer); err != nil {
+	if err := parseable.Parse(&ctx.PeekingLexer); err != nil {
 		if err == NextMatch {
 			err = &UnexpectedTokenError{Unexpected: *ctx.Peek()}
 		} else {


### PR DESCRIPTION
Hi @alecthomas,

when rebasing #213 to master, I decided it would be best to commit my stuff in smaller chunks. The first chunk is some optimizations I did to `PeekingLexer` as it was becoming the bottleneck to the generated parser implementation.

1. **Optimizing `PeekingLexer.Clone` - `Checkpoint`**
    It does an allocation that could be avoided. One way is to just have `parseContext` and my generated code to store it by value (keeping pointer receiver for its methods though). This already helps quite a lot, but I went a bit further in my generated code - wrapping the internal cursors in a public `lexer.Checkpoint` type. When a branch needs a backup of the `PeekingLexer` state, it will just need to copy this small struct and restore it only if the branch was *not* accepted and it's even a little bit faster than copying & replacing the entire `PeekingLexer` struct.
2. **Optimizing `PeekingLexer.Clone` - removing it**
    Using the `Checkpoint` pattern in the reflection parser is tough as it needs to explicitly apply an accepted branch instead of reverting to a backup of a failed branch (the way that was nicer to use in the generated code). So my proposal would be to keep the `Checkpoint` pattern only for generated code. But I added a commit (independent of my other changes) that I can include if you like that stores `PeekingLexer` in `parseContext` by value and avoids the `Clone` allocation altogether.
3. **Optimizing `PeekingLexer.Peek`**
    Currently `Peek` (which is used quite often by the reflective parser and even more often by my generated parser) needs to skip elided tokens every time it's called. It also checks for the length of `PeekingLexer.tokens` and returns `p.eof` in a lot of places - I think it's more elegant to just have the EOF token as the last token and prevent `Next` from advancing beyond it.
    This optimization does this work once in `Upgrade` and `Next` and makes `Peek` super simple, it also removes the `eof` field. The performance improvement for the Thrift benchmark is barely noticeable, but a separate benchmark I added shows a >3x improvement for `Peek` calls; it was also more more noticeable in my generated parser.
    I mentioned this whole thing in point 2 in https://github.com/alecthomas/participle/issues/213#issuecomment-1055395492 as the initial implementation changed the behavior of `RawCursor` and thus also `Range`. This new implementation adds a separate cursor for knowing when the next non-elided token is, making it a bit slower, but prevents a change of behavior.

4. **Working with `lexer.Token` as pointer**
    `Token` is not a small struct and in most cases it's more efficient to work with it as a pointer instead of copying it - assuming of course no allocations are needed as the tokens are already stored in `PeekingLexer.tokens`. Changing `Token` methods to a pointer receiver alone improved CPU perf in the Thrift benchmark by ~2.5%, trying to make `Next`, `Peek` and other methods return it as a pointer made the improvement ~4%. Such a
    Considering this would be a breaking change to a public (somewhat internal, but still public) API, I decided it wasn't worth it. But if you think it's OK, I still added a new method `Current`, which is a version of `Peek` that returns a pointer. `BenchmarkPeekingLexer_Current` still shows that almost 3x faster than `Peek`. If you don't like it, I don't need to include it. I also used pointers at least inside the `PeekingLexer` methods and got a tiny CPU improvement in the Thrift benchmark out of it.

5. **`BatchLexer` interface**
    This is actually unrelated to the code generation, but when playing with a manually written lexer for Jinja, I found it both more convenient and more efficient (thanks to a much lower number of function calls and more efficient allocations) to have the ability to yield multiple (in my case up to 50) tokens at a time. The interface and the related implementation is just a soft suggestion, if you don't like it, I can remove it. But it's optional - if a `Lexer` chooses to implement it, it can gain extra performance, if it doesn't, no problem.

After all but the last optimization (`BatchLexer` isn't used by any built-in lexer - yet), the final comparison looks like:
```
BenchmarkParticipleThriftGenerated-Before-8   	   12105	    292277 ns/op	        27.46 MiB/s	  178816 B/op	    2167 allocs/op
BenchmarkParticipleThriftGenerated-After-8   	   12597	    269844 ns/op	        28.58 MiB/s	  161920 B/op	    1903 allocs/op
```

Perhaps even more important is that according to a profiler, now it spends almost 7x less time in the `PeekingLexer` methods which I intended to optimize.