### PR TITLE
fix: proper generated struct name for state change

### DIFF
--- a/cmd/participle/gen_lexer_cmd.go
+++ b/cmd/participle/gen_lexer_cmd.go
@@ -170,7 +170,7 @@ func (l *lexer{{.Name}}Impl) Next() (lexer.Token, error) {
 		if true {
 {{- end}}
 {{- if .|IsPush}}
-			l.states = append(l.states, lexer{{.Name}}State{name: "{{.|IsPush}}"{{if HaveBackrefs $.Def $state.Name}}, groups: l.sgroups(groups){{end}}})
+			l.states = append(l.states, lexer{{$.Name}}State{name: "{{.|IsPush}}"{{if HaveBackrefs $.Def $state.Name}}, groups: l.sgroups(groups){{end}}})
 {{- else if (or (.|IsPop) (.|IsReturn))}}
 			l.states = l.states[:len(l.states)-1]
 {{- if .|IsReturn}}

--- a/cmd/participle/gen_lexer_cmd.go
+++ b/cmd/participle/gen_lexer_cmd.go
@@ -163,7 +163,7 @@ func (l *lexer{{.Name}}Impl) Next() (lexer.Token, error) {
 {{- range $i, $rule := $state.Rules}}
 		{{- if $i}} else {{end -}}
 {{- if .Pattern -}}
-		if match := match{{.Name}}(l.s, l.p); match[1] != 0 {
+		if match := match{{$.Name}}{{.Name}}(l.s, l.p); match[1] != 0 {
 			sym = {{index $.Def.Symbols .Name}}
 			groups = match[:]
 {{- else if .|IsReturn -}}
@@ -234,7 +234,7 @@ func generateLexer(w io.Writer, pkg string, def *lexer.StatefulDefinition, name 
 			}
 			seen[rule.Name] = true
 			fmt.Fprintf(w, "\n")
-			err := generateRegexMatch(w, rule.Name, rule.Pattern)
+			err := generateRegexMatch(w, name, rule.Name, rule.Pattern)
 			if err != nil {
 				return err
 			}
@@ -262,7 +262,7 @@ func orderRules(rules lexer.Rules) []orderedRule {
 	return orderedRules
 }
 
-func generateRegexMatch(w io.Writer, name, pattern string) error {
+func generateRegexMatch(w io.Writer, lexerName, name, pattern string) error {
 	re, err := syntax.Parse(pattern, syntax.Perl)
 	if err != nil {
 		return err
@@ -287,7 +287,7 @@ func generateRegexMatch(w io.Writer, name, pattern string) error {
 	}
 	re = re.Simplify()
 	fmt.Fprintf(w, "// %s\n", re)
-	fmt.Fprintf(w, "func match%s(s string, p int) (groups [%d]int) {\n", name, 2*re.MaxCap()+2)
+	fmt.Fprintf(w, "func match%s%s(s string, p int) (groups [%d]int) {\n", lexerName, name, 2*re.MaxCap()+2)
 	flattened := flatten(re)
 
 	// Fast-path a single literal.

--- a/lexer/internal/basiclexer.go
+++ b/lexer/internal/basiclexer.go
@@ -78,25 +78,25 @@ func (l *lexerGeneratedBasicImpl) Next() (lexer.Token, error) {
 	)
 	switch state.name {
 	case "Root":
-		if match := matchString(l.s, l.p); match[1] != 0 {
+		if match := matchGeneratedBasicString(l.s, l.p); match[1] != 0 {
 			sym = -2
 			groups = match[:]
-		} else if match := matchNumber(l.s, l.p); match[1] != 0 {
+		} else if match := matchGeneratedBasicNumber(l.s, l.p); match[1] != 0 {
 			sym = -3
 			groups = match[:]
-		} else if match := matchIdent(l.s, l.p); match[1] != 0 {
+		} else if match := matchGeneratedBasicIdent(l.s, l.p); match[1] != 0 {
 			sym = -4
 			groups = match[:]
-		} else if match := matchPunct(l.s, l.p); match[1] != 0 {
+		} else if match := matchGeneratedBasicPunct(l.s, l.p); match[1] != 0 {
 			sym = -5
 			groups = match[:]
-		} else if match := matchEOL(l.s, l.p); match[1] != 0 {
+		} else if match := matchGeneratedBasicEOL(l.s, l.p); match[1] != 0 {
 			sym = -6
 			groups = match[:]
-		} else if match := matchComment(l.s, l.p); match[1] != 0 {
+		} else if match := matchGeneratedBasicComment(l.s, l.p); match[1] != 0 {
 			sym = -7
 			groups = match[:]
-		} else if match := matchWhitespace(l.s, l.p); match[1] != 0 {
+		} else if match := matchGeneratedBasicWhitespace(l.s, l.p); match[1] != 0 {
 			sym = -8
 			groups = match[:]
 		}
@@ -128,7 +128,7 @@ func (l *lexerGeneratedBasicImpl) sgroups(match []int) []string {
 }
 
 // "(\\"|[^"])*"
-func matchString(s string, p int) (groups [4]int) {
+func matchGeneratedBasicString(s string, p int) (groups [4]int) {
 	// " (Literal)
 	l0 := func(s string, p int) int {
 		if p < len(s) && s[p] == '"' {
@@ -218,7 +218,7 @@ func matchString(s string, p int) (groups [4]int) {
 }
 
 // [\+\-]?([0-9]*\.)?[0-9]+
-func matchNumber(s string, p int) (groups [4]int) {
+func matchGeneratedBasicNumber(s string, p int) (groups [4]int) {
 	// [\+\-] (CharClass)
 	l0 := func(s string, p int) int {
 		if len(s) <= p {
@@ -333,7 +333,7 @@ func matchNumber(s string, p int) (groups [4]int) {
 }
 
 // [A-Z_a-z][0-9A-Z_a-z]*
-func matchIdent(s string, p int) (groups [2]int) {
+func matchGeneratedBasicIdent(s string, p int) (groups [2]int) {
 	// [A-Z_a-z] (CharClass)
 	l0 := func(s string, p int) int {
 		if len(s) <= p {
@@ -399,7 +399,7 @@ func matchIdent(s string, p int) (groups [2]int) {
 }
 
 // [!-/:-@\[-`\{-~]+
-func matchPunct(s string, p int) (groups [2]int) {
+func matchGeneratedBasicPunct(s string, p int) (groups [2]int) {
 	// [!-/:-@\[-`\{-~] (CharClass)
 	l0 := func(s string, p int) int {
 		if len(s) <= p {
@@ -442,7 +442,7 @@ func matchPunct(s string, p int) (groups [2]int) {
 }
 
 // \n
-func matchEOL(s string, p int) (groups [2]int) {
+func matchGeneratedBasicEOL(s string, p int) (groups [2]int) {
 	if p < len(s) && s[p] == '\n' {
 		groups[0] = p
 		groups[1] = p + 1
@@ -451,7 +451,7 @@ func matchEOL(s string, p int) (groups [2]int) {
 }
 
 // (?i:REM)[^\n]*(?i:\n)
-func matchComment(s string, p int) (groups [2]int) {
+func matchGeneratedBasicComment(s string, p int) (groups [2]int) {
 	// (?i:REM) (Literal)
 	l0 := func(s string, p int) int {
 		if p+3 < len(s) && s[p:p+3] == "REM" {
@@ -522,7 +522,7 @@ func matchComment(s string, p int) (groups [2]int) {
 }
 
 // [\t ]+
-func matchWhitespace(s string, p int) (groups [2]int) {
+func matchGeneratedBasicWhitespace(s string, p int) (groups [2]int) {
 	// [\t ] (CharClass)
 	l0 := func(s string, p int) int {
 		if len(s) <= p {


### PR DESCRIPTION
The generated struct name is now correct (uses name specified on command line) instead of using the name of the rule.

Tested that the generated lexer code now properly compiles without manual modification.