### PR TITLE
Fix gen lexer word boundary, case insensitive, and literal matching cases (plus conformance tests)

### DIFF
--- a/cmd/participle/gen_lexer_cmd.go
+++ b/cmd/participle/gen_lexer_cmd.go
@@ -189,12 +189,12 @@ func generateRegexMatch(w io.Writer, lexerName, name, pattern string) error {
 	if len(flattened) == 1 && re.Op == syntax.OpLiteral {
 		n := utf8.RuneCountInString(string(re.Rune))
 		if re.Flags&syntax.FoldCase != 0 {
-			fmt.Fprintf(w, "if p+%d < len(s) && strings.EqualFold(s[p:p+%d], %q) {\n", n, n, string(re.Rune))
+			fmt.Fprintf(w, "if p+%d <= len(s) && strings.EqualFold(s[p:p+%d], %q) {\n", n, n, string(re.Rune))
 		} else {
 			if n == 1 {
 				fmt.Fprintf(w, "if p < len(s) && s[p] == %q {\n", re.Rune[0])
 			} else {
-				fmt.Fprintf(w, "if p+%d < len(s) && s[p:p+%d] == %q {\n", n, n, string(re.Rune))
+				fmt.Fprintf(w, "if p+%d <= len(s) && s[p:p+%d] == %q {\n", n, n, string(re.Rune))
 			}
 		}
 		fmt.Fprintf(w, "groups[0] = p\n")
@@ -224,12 +224,12 @@ func generateRegexMatch(w io.Writer, lexerName, name, pattern string) error {
 		case syntax.OpLiteral: // matches Runes sequence
 			n := utf8.RuneCountInString(string(re.Rune))
 			if re.Flags&syntax.FoldCase != 0 {
-				fmt.Fprintf(w, "if p+%d < len(s) && strings.EqualFold(s[p:p+%d], %q) { return p+%d }\n", n, n, string(re.Rune), n)
+				fmt.Fprintf(w, "if p+%d <= len(s) && strings.EqualFold(s[p:p+%d], %q) { return p+%d }\n", n, n, string(re.Rune), n)
 			} else {
 				if n == 1 {
 					fmt.Fprintf(w, "if p < len(s) && s[p] == %q { return p+1 }\n", re.Rune[0])
 				} else {
-					fmt.Fprintf(w, "if p+%d < len(s) && s[p:p+%d] == %q { return p+%d }\n", n, n, string(re.Rune), n)
+					fmt.Fprintf(w, "if p+%d <= len(s) && s[p:p+%d] == %q { return p+%d }\n", n, n, string(re.Rune), n)
 				}
 			}
 			fmt.Fprintf(w, "return -1\n")

--- a/cmd/participle/gen_lexer_cmd.go
+++ b/cmd/participle/gen_lexer_cmd.go
@@ -292,11 +292,13 @@ func generateRegexMatch(w io.Writer, lexerName, name, pattern string) error {
 			syntax.OpBeginText, syntax.OpEndText,
 			syntax.OpBeginLine, syntax.OpEndLine:
 			fmt.Fprintf(w, "var l, u rune = -1, -1\n")
+			fmt.Fprintf(w, "var checkPrevChar = false\n")
 			fmt.Fprintf(w, "if p == 0 {\n")
 			decodeRune(w, "0", "u", "_")
 			fmt.Fprintf(w, "} else if p == len(s) {\n")
 			fmt.Fprintf(w, "  l, _ = utf8.DecodeLastRuneInString(s)\n")
 			fmt.Fprintf(w, "} else {\n")
+			fmt.Fprintf(w, "  checkPrevChar = true\n")
 			fmt.Fprintf(w, "  var ln int\n")
 			decodeRune(w, "p", "l", "ln")
 			fmt.Fprintf(w, "  if p+ln <= len(s) {\n")
@@ -313,6 +315,16 @@ func generateRegexMatch(w io.Writer, lexerName, name, pattern string) error {
 				syntax.OpEndLine:        "EmptyEndLine",
 			}
 			fmt.Fprintf(w, "if op & syntax.%s != 0 { return p }\n", lut[re.Op])
+			// If this isn't the start or end of the string, we also have to check if we match
+			// the preceding character (zero length op could have matched right before)
+			fmt.Fprintf(w, "if checkPrevChar {\n")
+			// decode the character immediately previous to this one (conditional logic above
+			// guarantees that p is > 0)
+			fmt.Fprintf(w, "  l, _ = utf8.DecodeLastRuneInString(s[0:p])\n")
+			decodeRune(w, "p", "u", "_")
+			fmt.Fprintf(w, "  op := syntax.EmptyOpContext(l, u)\n")
+			fmt.Fprintf(w, "  if op & syntax.%s != 0 { return p }\n", lut[re.Op])
+			fmt.Fprintf(w, "}\n")
 			fmt.Fprintf(w, "return -1\n")
 
 		case syntax.OpCapture: // capturing subexpression with index Cap, optional name Name

--- a/lexer/internal/conformance/conformance_test.go
+++ b/lexer/internal/conformance/conformance_test.go
@@ -18,6 +18,7 @@ var conformanceLexer = lexer.MustStateful(lexer.Rules{
 	"Root": {
 		{"String", `"`, lexer.Push("String")},
 		// {"Heredoc", `<<(\w+)`, lexer.Push("Heredoc")},
+		{"LiteralTest", `LITTEST:`, lexer.Push("LiteralTest")},
 		{"CaseInsensitiveTest", `CITEST:`, lexer.Push("CaseInsensitiveTest")},
 		{"WordBoundaryTest", `WBTEST:`, lexer.Push("WordBoundaryTest")},
 	},
@@ -43,6 +44,12 @@ var conformanceLexer = lexer.MustStateful(lexer.Rules{
 	// 	{"End", `\1`, lexer.Pop()},
 	// 	lexer.Include("Expr"),
 	// },
+	"LiteralTest": {
+		{`LITOne`, `ONE`, nil},
+		{`LITKeyword`, `SELECT|FROM|WHERE|LIKE`, nil},
+		{"Ident", `\w+`, nil},
+		{"Whitespace", `\s+`, nil},
+	},
 	"CaseInsensitiveTest": {
 		{`ABCWord`, `[aA][bB][cC]`, nil},
 		{`CIKeyword`, `(?i)(SELECT|from|WHERE|LIKE)`, nil},
@@ -127,6 +134,26 @@ func testLexer(t *testing.T, lex lexer.Definition) {
 			{"CIKeyword", "where"},
 			{"Whitespace", " "},
 			{"Ident", "END"},
+		}},
+		{"OneLiteralAtEnd", `LITTEST:ONE`, []token{
+			{"LiteralTest", "LITTEST:"},
+			{"LITOne", "ONE"},
+		}},
+		{"KeywordLiteralAtEnd", `LITTEST:SELECT`, []token{
+			{"LiteralTest", "LITTEST:"},
+			{"LITKeyword", "SELECT"},
+		}},
+		{"LiteralMixed", `LITTEST:hello ONE test LIKE world`, []token{
+			{"LiteralTest", "LITTEST:"},
+			{"Ident", "hello"},
+			{"Whitespace", " "},
+			{"LITOne", "ONE"},
+			{"Whitespace", " "},
+			{"Ident", "test"},
+			{"Whitespace", " "},
+			{"LITKeyword", "LIKE"},
+			{"Whitespace", " "},
+			{"Ident", "world"},
 		}},
 		{"WordBoundarySlash", `WBTEST:xyz/hello world`, []token{
 			{"WordBoundaryTest", "WBTEST:"},

--- a/lexer/internal/conformance/conformance_test.go
+++ b/lexer/internal/conformance/conformance_test.go
@@ -18,6 +18,7 @@ var conformanceLexer = lexer.MustStateful(lexer.Rules{
 	"Root": {
 		{"String", `"`, lexer.Push("String")},
 		// {"Heredoc", `<<(\w+)`, lexer.Push("Heredoc")},
+		{"WordBoundaryTest", `WBTEST:`, lexer.Push("WordBoundaryTest")},
 	},
 	"String": {
 		{"Escaped", `\\.`, nil},
@@ -41,6 +42,12 @@ var conformanceLexer = lexer.MustStateful(lexer.Rules{
 	// 	{"End", `\1`, lexer.Pop()},
 	// 	lexer.Include("Expr"),
 	// },
+	"WordBoundaryTest": {
+		{Name: `ABCWord`, Pattern: `[aA][bB][cC]\b`, Action: nil},
+		{Name: "Slash", Pattern: `/`, Action: nil},
+		{Name: "Ident", Pattern: `\w+`, Action: nil},
+		{Name: "Whitespace", Pattern: `\s+`, Action: nil},
+	},
 })
 
 type token struct {
@@ -92,6 +99,22 @@ func testLexer(t *testing.T, lex lexer.Definition) {
 		// 			{"Whitespace", "\n"},
 		// 			{"End", "EOF"},
 		// 		}},
+		{"WordBoundarySlash", `WBTEST:aBC/hello world`, []token{
+			{"WordBoundaryTest", "WBTEST:"},
+			{"ABCWord", "aBC"},
+			{"Slash", "/"},
+			{"Ident", "hello"},
+			{"Whitespace", " "},
+			{"Ident", "world"},
+		}},
+		{"WordBoundaryWhitespace", `WBTEST:aBChello Abc world`, []token{
+			{"WordBoundaryTest", "WBTEST:"},
+			{"Ident", "aBChello"},
+			{"Whitespace", " "},
+			{"ABCWord", "Abc"},
+			{"Whitespace", " "},
+			{"Ident", "world"},
+		}},
 	}
 	symbols := lexer.SymbolsByRune(lex)
 	for _, test := range tests {

--- a/lexer/internal/conformance/conformance_test.go
+++ b/lexer/internal/conformance/conformance_test.go
@@ -117,7 +117,7 @@ func TestLexerConformanceGenerated(t *testing.T) {
 	args := []string{"test", "-run", "TestLexerConformanceGeneratedInternal", "-tags", "generated"}
 	// Propagate test flags.
 	flag.CommandLine.VisitAll(func(f *flag.Flag) {
-		if f.Value.String() != f.DefValue {
+		if f.Value.String() != f.DefValue && f.Name != "test.run" {
 			args = append(args, fmt.Sprintf("-%s=%s", f.Name, f.Value.String()))
 		}
 	})


### PR DESCRIPTION
@alecthomas - I wanted to get your feedback early on the approach to add a specialized test to the conformance test suite. It uses a special token (e.g., `WBTEST:`) to push into a new lexer state that then might have different rules vs the rest of the grammar. This would allow for testing different areas of the lexer without having to add more and more rules to the Root state (which might start interacting with each other over time as the number of conformance test cases grow and the rules get more complex).

Opening as a draft to get your feedback on the approach. This demonstrates how the generated lexer currently doesn't support the word boundary `\b` regex properly. (Will next see what might be needed to fix this in the lexer generation.)

This also tweaks `TestLexerConformanceGenerated` so that if you run this test function from VSCode IDE it won't just hang forever (the command that eventually gets run before this change was `go test -run TestLexerConformanceGeneratedInternal -tags generated '-test.run=^TestLexerConformanceGenerated$'`, which confuses go and causes it to hang forever until Ctrl+C is pressed).