### PR TITLE
Pooled version of lexer.Upgrade

### DIFF
--- a/lexer/peek.go
+++ b/lexer/peek.go
@@ -63,13 +63,15 @@ var peekingLexerPool = sync.Pool{
 // "elide" is a slice of token types to elide from processing.
 //
 // You must call `PutBackPooledPeekingLexer` once done with the
-// returned lexer in all cases (ok or error).
+// returned lexer in all cases (ok or error). If you use the lexer with
+// the parser (`Parser.ParseFromLexer`), note that the parsed results
+// might refer back to lexer tokens, in which case you should not call
+// PutBackPooledPeekingLexer until you have finished with the parser
+// results as well.
 func UpgradePooled(lex Lexer, elide ...TokenType) (*PeekingLexer, error) {
 	r := peekingLexerPool.Get().(*PeekingLexer)
 	// reset the state of the PeekingLexer to empty (preserving any allocated capacity)
-	r.Checkpoint.cursor = 0
-	r.Checkpoint.rawCursor = 0
-	r.Checkpoint.nextCursor = 0
+	r.Checkpoint = Checkpoint{}
 	// note: this preserves capacity
 	r.tokens = r.tokens[:0]
 	for k := range r.elide {

--- a/lexer/peek.go
+++ b/lexer/peek.go
@@ -57,8 +57,8 @@ var peekingLexerPool = sync.Pool{
 	},
 }
 
-// Upgrade a Lexer to a PeekingLexer with arbitrary lookahead.
-// Faster if you need to lex thousands of similar documents.
+// UpgradePooled will upgrade a Lexer to a PeekingLexer with arbitrary
+// lookahead. Faster if you need to lex thousands of similar documents.
 //
 // "elide" is a slice of token types to elide from processing.
 //

--- a/lexer/peek_test.go
+++ b/lexer/peek_test.go
@@ -89,8 +89,8 @@ func BenchmarkPeekingLexer_Peek(b *testing.B) {
 func generateTokenArray(sz int) []lexer.Token {
 	tokens := make([]lexer.Token, sz)
 	for i := range tokens {
-		tokens[i].Type = lexer.TokenType(rand.Int() % 3)
-		tokens[i].Value = string([]byte{byte('a' + (rand.Int() % 26))})
+		tokens[i].Type = lexer.TokenType(rand.Int() % 3)                /* #nosec */
+		tokens[i].Value = string([]byte{byte('a' + (rand.Int() % 26))}) /* #nosec */
 	}
 	return tokens
 }

--- a/lexer/peek_test.go
+++ b/lexer/peek_test.go
@@ -1,6 +1,7 @@
 package lexer_test
 
 import (
+	"math/rand"
 	"testing"
 
 	require "github.com/alecthomas/assert/v2"
@@ -27,6 +28,19 @@ func TestUpgrade(t *testing.T) {
 	t1 := lexer.Token{Type: 2, Value: "blah"}
 	tokens := []lexer.Token{t0, ts, t1}
 	l, err := lexer.Upgrade(&staticLexer{tokens: tokens}, 3)
+	require.NoError(t, err)
+	require.Equal(t, t0, *l.Peek())
+	require.Equal(t, t0, *l.Peek())
+	require.Equal(t, tokens, l.Range(0, 3))
+}
+
+func TestUpgradePooled(t *testing.T) {
+	t0 := lexer.Token{Type: 1, Value: "moo"}
+	ts := lexer.Token{Type: 3, Value: " "}
+	t1 := lexer.Token{Type: 2, Value: "blah"}
+	tokens := []lexer.Token{t0, ts, t1}
+	l, err := lexer.UpgradePooled(&staticLexer{tokens: tokens}, 3)
+	defer lexer.PutBackPooledPeekingLexer(l)
 	require.NoError(t, err)
 	require.Equal(t, t0, *l.Peek())
 	require.Equal(t, t0, *l.Peek())
@@ -70,4 +84,38 @@ func BenchmarkPeekingLexer_Peek(b *testing.B) {
 		}
 	}
 	require.Equal(b, lexer.Token{Type: 2, Value: "y"}, *t)
+}
+
+func generateTokenArray(sz int) []lexer.Token {
+	tokens := make([]lexer.Token, sz)
+	for i := range tokens {
+		tokens[i].Type = lexer.TokenType(rand.Int() % 3)
+		tokens[i].Value = string([]byte{byte('a' + (rand.Int() % 26))})
+	}
+	return tokens
+}
+
+func BenchmarkPeekingLexer_Upgrade(b *testing.B) {
+	tokens := generateTokenArray(10000)
+	testLexer := &staticLexer{tokens: tokens}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l, err := lexer.Upgrade(testLexer)
+		require.NoError(b, err)
+		l.Next()
+		l.Peek()
+	}
+}
+
+func BenchmarkPeekingLexer_UpgradePooled(b *testing.B) {
+	tokens := generateTokenArray(10000)
+	testLexer := &staticLexer{tokens: tokens}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l, err := lexer.UpgradePooled(testLexer)
+		require.NoError(b, err)
+		l.Next()
+		l.Peek()
+		lexer.PutBackPooledPeekingLexer(l)
+	}
 }


### PR DESCRIPTION
As observed in https://github.com/alecthomas/participle/issues/213#issuecomment-1344945666, can result in 10% - 30% overall lexing/parsing speedup in cases where needing to lex/parse thousands of documents of a similar size all in a row.

Added a microbenchmark as well showing >4x speedup of `Upgrade` operation itself if used repeatedly for docs of a similar size.