### PR TITLE
Fixes "false" in example/expr2

### DIFF
--- a/_examples/expr2/main.go
+++ b/_examples/expr2/main.go
@@ -58,9 +58,16 @@ type Unary struct {
 type Primary struct {
 	Number        *float64    `  @Float | @Int`
 	String        *string     `| @String`
-	Bool          *bool       `| ( @"true" | "false" )`
+	Bool          *Boolean    `| @( "true" | "false" )`
 	Nil           bool        `| @"nil"`
 	SubExpression *Expression `| "(" @@ ")" `
+}
+
+type Boolean bool
+
+func (b *Boolean) Capture(values []string) error {
+	*b = values[0] == "true"
+	return nil
 }
 
 var parser = participle.MustBuild[Expression](participle.UseLookahead(2))

--- a/_examples/expr2/main_test.go
+++ b/_examples/expr2/main_test.go
@@ -12,3 +12,40 @@ func TestExe(t *testing.T) {
 	repr.Println(expr)
 	require.NoError(t, err)
 }
+
+func toPtr[T any](x T) *T {
+	return &x
+}
+
+func TestExe_BoolFalse(t *testing.T) {
+	got, err := parser.ParseString("", `1 + false`)
+
+	expected := &Expression{
+		Equality: &Equality{
+			Comparison: &Comparison{
+				Addition: &Addition{
+					Multiplication: &Multiplication{
+						Unary: &Unary{
+							Primary: &Primary{
+								Number: toPtr(float64(1)),
+							},
+						},
+					},
+					Op: "+",
+					Next: &Addition{
+						Multiplication: &Multiplication{
+							Unary: &Unary{
+								Primary: &Primary{
+									Bool: toPtr(false),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}

--- a/_examples/expr2/main_test.go
+++ b/_examples/expr2/main_test.go
@@ -36,7 +36,7 @@ func TestExe_BoolFalse(t *testing.T) {
 						Multiplication: &Multiplication{
 							Unary: &Unary{
 								Primary: &Primary{
-									Bool: toPtr(false),
+									Bool: toPtr(Boolean(false)),
 								},
 							},
 						},


### PR DESCRIPTION
The expression `1 + false` didn't parse well.
The second `Primary` is empty, as per first commit's tests fails.

Adding a `Boolean` type wrapper to handle it and helps newbies (like me) to start using the library.