### PR TITLE
avoid returning errors when one-or-more groups have no matches

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -282,7 +282,8 @@ func (g *group) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.Va
 	if matches >= MaxIterations {
 		return nil, Errorf(t.Pos, "too many iterations of %s (> %d)", g, MaxIterations)
 	}
-	if matches < min {
+	// avoid returning errors in parent nodes if the group is optional
+	if matches > 0 && matches < min {
 		return out, Errorf(t.Pos, "sub-expression %s must match at least once", g)
 	}
 	// The idea here is that something like "a"? is a successful match and that parsing should proceed.


### PR DESCRIPTION
We had an issue using participle when using a structure like the following 
```go
type Union struct {
	Float float64 `( @Float` 
	String string ` | @String+`
    Bool bool     ` | @Boolean )` 
}
```

The code works as intended, but when you use a `@String+` as a part of your union types your error messages get a lot less helpful. Instead of getting errors like 
> 1:1: unexpected token "102"

most of your errors turn into 
> 1:1: sub-expression <string>+ must match at least once

This ends up this way because the group node returns an error when `@Foo+` doesn't match the minimum quantity which then overrides any other useful error reporting and failthroughs 

This small change makes it so that the error is only reported if there is at least one match in a group (and adds a test to enforce it) 
