### PR TITLE
fix(scripts): add GOBIN fallback and support any cwd

### DIFF
--- a/scripts/participle
+++ b/scripts/participle
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-[[ -d "$(go env GOBIN)" ]] || GOBIN=$(go env GOPATH)/bin
+GOBIN=$(go env GOBIN)
+[[ -d "${GOBIN}" ]] || GOBIN=$(go env GOPATH)/bin
 go install -C "$(dirname "$0")/../cmd/participle" 'github.com/alecthomas/participle/v2/cmd/participle'
 exec "${GOBIN}/participle" "$@"

--- a/scripts/participle
+++ b/scripts/participle
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-(cd "$(dirname "$0")/../cmd/participle" && go install github.com/alecthomas/participle/v2/cmd/participle)
-exec "$(go env GOBIN)/participle" "$@"
+[[ -d "$(go env GOBIN)" ]] || GOBIN=$(go env GOPATH)/bin
+go install -C "$(dirname "$0")/../cmd/participle" 'github.com/alecthomas/participle/v2/cmd/participle'
+exec "${GOBIN}/participle" "$@"

--- a/scripts/regen-lexer
+++ b/scripts/regen-lexer
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-participle gen lexer --name GeneratedBasic internal < lexer/internal/basiclexer.json | gofmt > lexer/internal/basiclexer.go
+path=$(dirname "${0}")
+base="${path}/../lexer/internal/basiclexer"
+"${path}/participle" gen lexer --name GeneratedBasic internal < "${base}.json" | gofmt > "${base}.go"


### PR DESCRIPTION
It is not required to have `GOBIN` defined, which was a situation I just encountered. 

This fix adds a fallback to use `GOPATH/bin` when `GOBIN` is undefined.

A couple other improvements:

- Use the `go install -C CWD` command-line flag to build from `CWD` instead of using a subshell `(cd CWD; go install ...)`.
- Use paths relative to the `regen-lexer` script for resolving both the neighboring `participle` script and the input/output files.
	- This allows `regen-lexer` to be called from _any_ directory (not just the project root).