### PR TITLE
doc(readme): fix invalid stateful lexer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,22 +363,22 @@ the [stateful example](https://github.com/alecthomas/participle/tree/master/_exa
 for the corresponding parser.
 
 ```go
-var lexer = lexer.Must(Rules{
+var def = lexer.Must(lexer.Rules{
 	"Root": {
-		{`String`, `"`, Push("String")},
+		{`String`, `"`, lexer.Push("String")},
 	},
 	"String": {
 		{"Escaped", `\\.`, nil},
-		{"StringEnd", `"`, Pop()},
-		{"Expr", `\${`, Push("Expr")},
+		{"StringEnd", `"`, lexer.Pop()},
+		{"Expr", `\${`, lexer.Push("Expr")},
 		{"Char", `[^$"\\]+`, nil},
 	},
 	"Expr": {
-		Include("Root"),
+		lexer.Include("Root"),
 		{`whitespace`, `\s+`, nil},
 		{`Oper`, `[-+/*%]`, nil},
 		{"Ident", `\w+`, nil},
-		{"ExprEnd", `}`, Pop()},
+		{"ExprEnd", `}`, lexer.Pop()},
 	},
 })
 ```


### PR DESCRIPTION
This change replaces the [example var declaration in `README.md`] with code from the [referenced example].

The example code is invalid for a couple reasons:

1. Only the outermost `lexer.Must` call is package-qualified, while all other calls to the same package are not.
2. The name of the variable being assigned `lexer` shadows the package, making all package exports inaccessible.

[example var declaration in `README.md`]: https://github.com/alecthomas/participle#example-stateful-lexer
[referenced example]: https://github.com/alecthomas/participle/blob/bcbb39153e17f8018257f17aba8eac628d396b64/_examples/stateful/main.go#L34-L51