### PR TITLE
Fix railroad diagram generation for 'require non-empty match' modifier

### DIFF
--- a/cmd/railroad/main.go
+++ b/cmd/railroad/main.go
@@ -90,15 +90,17 @@ h1 {
 		s += ")"
 
 	case *ebnf.Term:
+		closeParen := false
 		switch n.Repetition {
 		case "*":
 			s += "ZeroOrMore("
+			closeParen = true
 		case "+":
 			s += "OneOrMore("
+			closeParen = true
 		case "?":
 			s += "Optional("
-		case "!":
-			s += "("
+			closeParen = true
 		}
 		switch {
 		case n.Name != "":
@@ -122,7 +124,7 @@ h1 {
 			panic(repr.String(n))
 
 		}
-		if n.Repetition != "" {
+		if closeParen {
 			s += ")"
 		}
 		if n.Negation {


### PR DESCRIPTION
When generating a diagram for a grammar that uses the `!` modifier, invalid JS is generated.
For example, the grammar `A = (B? C?)! .` would be rendered to `Diagram(Choice(0, Sequence((Choice(0, Sequence(Optional(NonTerminal("A", {href:"#A"})), Optional(NonTerminal("B", {href:"#B"})))))))).addTo();`. This is invalid due to an extra closing parenthesis. As there doesn't seem to be an appropriate container in [railroad-diagrams](https://www.npmjs.com/package/railroad-diagrams), this PR attempts to fix the problem by only appending an additional closing paren when a corresponding open paren was previously prepended.