### PR TITLE
Don't apply enclosing struct captures when a branch fails

### DIFF
--- a/context.go
+++ b/context.go
@@ -52,12 +52,8 @@ func (p *parseContext) Defer(tokens []lexer.Token, strct reflect.Value, field st
 	p.apply = append(p.apply, &contextFieldSet{tokens, strct, field, fieldValue})
 }
 
-// ApplyFrom applies deferred functions added at or after the given offset into
-// the apply queue, leaving earlier deferred functions in place. Passing 0
-// applies every deferred function. A struct passes its own starting offset so
-// that, when it fails or completes, it applies only its own captures without
-// touching captures deferred by enclosing structs, which a discarded lookahead
-// branch may still need to drop.
+// ApplyFrom applies deferred functions from the given offset onwards, leaving
+// earlier ones queued for the enclosing struct.
 func (p *parseContext) ApplyFrom(start int) error {
 	for _, apply := range p.apply[start:] {
 		if err := setField(apply.tokens, apply.strct, apply.field, apply.fieldValue); err != nil {

--- a/context.go
+++ b/context.go
@@ -52,14 +52,19 @@ func (p *parseContext) Defer(tokens []lexer.Token, strct reflect.Value, field st
 	p.apply = append(p.apply, &contextFieldSet{tokens, strct, field, fieldValue})
 }
 
-// Apply deferred functions.
-func (p *parseContext) Apply() error {
-	for _, apply := range p.apply {
+// ApplyFrom applies deferred functions added at or after the given offset into
+// the apply queue, leaving earlier deferred functions in place. Passing 0
+// applies every deferred function. A struct passes its own starting offset so
+// that, when it fails or completes, it applies only its own captures without
+// touching captures deferred by enclosing structs, which a discarded lookahead
+// branch may still need to drop.
+func (p *parseContext) ApplyFrom(start int) error {
+	for _, apply := range p.apply[start:] {
 		if err := setField(apply.tokens, apply.strct, apply.field, apply.fieldValue); err != nil {
 			return err
 		}
 	}
-	p.apply = nil
+	p.apply = p.apply[:start]
 	return nil
 }
 

--- a/nodes.go
+++ b/nodes.go
@@ -152,10 +152,14 @@ func (s *strct) Parse(ctx *parseContext, _ reflect.Value) (out []reflect.Value, 
 	defer ctx.printTrace(s)()
 	sv := reflect.New(s.typ).Elem()
 	start := ctx.RawCursor()
+	applyStart := len(ctx.apply)
 	t := ctx.Peek()
 	s.maybeInjectStartToken(t, sv)
 	if out, err = s.expr.Parse(ctx, sv); err != nil {
-		_ = ctx.Apply() // Best effort to give partial AST.
+		// Best effort to give a partial AST, but only for this struct's own
+		// captures. Captures deferred by enclosing structs are left in place so
+		// a failed branch that gets discarded doesn't wrongly apply them.
+		_ = ctx.ApplyFrom(applyStart)
 		ctx.MaybeUpdateError(err)
 		return []reflect.Value{sv}, err
 	} else if out == nil {
@@ -165,7 +169,7 @@ func (s *strct) Parse(ctx *parseContext, _ reflect.Value) (out []reflect.Value, 
 	t = ctx.RawPeek()
 	s.maybeInjectEndToken(t, sv)
 	s.maybeInjectTokens(ctx.Range(start, end), sv)
-	return []reflect.Value{sv}, ctx.Apply()
+	return []reflect.Value{sv}, ctx.ApplyFrom(applyStart)
 }
 
 func (s *strct) maybeInjectStartToken(token *lexer.Token, v reflect.Value) {

--- a/nodes.go
+++ b/nodes.go
@@ -156,13 +156,13 @@ func (s *strct) Parse(ctx *parseContext, _ reflect.Value) (out []reflect.Value, 
 	t := ctx.Peek()
 	s.maybeInjectStartToken(t, sv)
 	if out, err = s.expr.Parse(ctx, sv); err != nil {
-		// Best effort to give a partial AST, but only for this struct's own
-		// captures. Captures deferred by enclosing structs are left in place so
-		// a failed branch that gets discarded doesn't wrongly apply them.
+		// Best effort to give a partial AST, but only for this struct's own captures:
+		// an enclosing struct's captures may still belong to a branch that gets dropped.
 		_ = ctx.ApplyFrom(applyStart)
 		ctx.MaybeUpdateError(err)
 		return []reflect.Value{sv}, err
 	} else if out == nil {
+		// No match, so the queue is back at applyStart: nothing to apply.
 		return nil, nil
 	}
 	end := ctx.RawCursor()

--- a/parser_test.go
+++ b/parser_test.go
@@ -1924,42 +1924,17 @@ func TestParseNumbers(t *testing.T) {
 	assert.Equal(t, grammar{Int: -30, Uint: 3000, Float: math.Inf(1)}, *result)
 }
 
-type bugFirstAlternative struct {
-	Value string `parser:"'#' @Ident"`
-}
-
-type bugStructCapturesInBadBranch struct {
-	Bad bool                `parser:"(@'!'"`
-	A   bugFirstAlternative `parser:" @@) |"`
-	B   int                 `parser:"('!' '#' @Int)"`
-}
-
-func TestStructCapturesInBadBranch(t *testing.T) {
-	parser := participle.MustBuild[bugStructCapturesInBadBranch](participle.UseLookahead(2))
+func TestIssue216(t *testing.T) {
+	type firstAlternative struct {
+		Value string `parser:"'#' @Ident"`
+	}
+	type grammar struct {
+		Bad bool             `parser:"(@'!'"`
+		A   firstAlternative `parser:" @@) |"`
+		B   int              `parser:"('!' '#' @Int)"`
+	}
+	parser := participle.MustBuild[grammar](participle.UseLookahead(2))
 	out, err := parser.ParseString("", "!#4")
 	assert.NoError(t, err)
-	assert.Equal(t, &bugStructCapturesInBadBranch{B: 4}, out)
-}
-
-type nestedCaptureL2 struct {
-	X string `parser:"@Ident"`
-}
-
-type nestedCaptureL1 struct {
-	Two nestedCaptureL2 `parser:"@@"`
-	B   string          `parser:"@Ident"`
-}
-
-type nestedCaptureL0 struct {
-	A   string          `parser:"@Ident"`
-	C   string          `parser:"@Ident"`
-	One nestedCaptureL1 `parser:"@@"`
-}
-
-// Regression test for #216: a nested struct succeeding and then an enclosing
-// struct failing must not slice out of the deferred-capture queue.
-func TestNestedStructCaptureNoPanic(t *testing.T) {
-	parser := participle.MustBuild[nestedCaptureL0](participle.UseLookahead(2))
-	_, err := parser.ParseString("", "a c x")
-	assert.Error(t, err)
+	assert.Equal(t, &grammar{B: 4}, out)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1923,3 +1923,43 @@ func TestParseNumbers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, grammar{Int: -30, Uint: 3000, Float: math.Inf(1)}, *result)
 }
+
+type bugFirstAlternative struct {
+	Value string `parser:"'#' @Ident"`
+}
+
+type bugStructCapturesInBadBranch struct {
+	Bad bool                `parser:"(@'!'"`
+	A   bugFirstAlternative `parser:" @@) |"`
+	B   int                 `parser:"('!' '#' @Int)"`
+}
+
+func TestStructCapturesInBadBranch(t *testing.T) {
+	parser := participle.MustBuild[bugStructCapturesInBadBranch](participle.UseLookahead(2))
+	out, err := parser.ParseString("", "!#4")
+	assert.NoError(t, err)
+	assert.Equal(t, &bugStructCapturesInBadBranch{B: 4}, out)
+}
+
+type nestedCaptureL2 struct {
+	X string `parser:"@Ident"`
+}
+
+type nestedCaptureL1 struct {
+	Two nestedCaptureL2 `parser:"@@"`
+	B   string          `parser:"@Ident"`
+}
+
+type nestedCaptureL0 struct {
+	A   string          `parser:"@Ident"`
+	C   string          `parser:"@Ident"`
+	One nestedCaptureL1 `parser:"@@"`
+}
+
+// Regression test for #216: a nested struct succeeding and then an enclosing
+// struct failing must not slice out of the deferred-capture queue.
+func TestNestedStructCaptureNoPanic(t *testing.T) {
+	parser := participle.MustBuild[nestedCaptureL0](participle.UseLookahead(2))
+	_, err := parser.ParseString("", "a c x")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Fixes #216.

`strct.Parse` flushed the entire deferred-capture queue when its expression failed (`ctx.Apply()`), applying captures that belong to enclosing structs. When a lookahead disjunction later discards that branch, those captures have already been written, e.g. the `Bad` field in the repro ends up `true`.

Each struct now snapshots its start offset into the queue and applies only its own captures, on both the success and failure paths, leaving enclosing structs' captures for those structs to apply. Removed the now-unused `Apply()`.

One behaviour change worth flagging: because an inner struct no longer flushes its enclosing structs' pending captures, the global order of `setField` calls across nested structs shifts. Field order within a struct is unchanged, so this is only observable through a `Capture()`/`UnmarshalText()` implementation with side effects.

Test: `TestIssue216`, the reporter's minimal repro. It fails on the unfixed parser with `Bad: true` and passes with the fix.

Used AI assistance on this; I reviewed and tested it.
