### PR TITLE
fix: prevent panic when struct implementing Capture is used with @@

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -627,15 +627,19 @@ func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField,
 
 	if f.CanAddr() {
 		if d, ok := f.Addr().Interface().(Capture); ok {
-			ifv := make([]string, 0, len(fieldValue))
-			for _, v := range fieldValue {
-				ifv = append(ifv, v.Interface().(string))
+			// Route through Capture unless fieldValue positively contains non-string
+			// values (from @@ struct captures), which Capture cannot accept.
+			isStructCapture := len(fieldValue) > 0 && fieldValue[0].Kind() != reflect.String
+			if !isStructCapture {
+				ifv := make([]string, 0, len(fieldValue))
+				for _, v := range fieldValue {
+					ifv = append(ifv, v.Interface().(string))
+				}
+				if err := d.Capture(ifv); err != nil {
+					return Wrapf(pos, err, "failed to capture")
+				}
+				return nil
 			}
-			err = d.Capture(ifv)
-			if err != nil {
-				return Wrapf(pos, err, "failed to capture")
-			}
-			return nil
 		} else if d, ok := f.Addr().Interface().(encoding.TextUnmarshaler); ok {
 			for _, v := range fieldValue {
 				if err := d.UnmarshalText([]byte(v.Interface().(string))); err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1622,6 +1622,39 @@ func (b *Box) Capture(values []string) error {
 	return nil
 }
 
+// Types for TestBoxedCaptureWithDoubleAt (issue #140)
+type innerCapture140 struct {
+	Val string `@Ident`
+}
+
+func (i *innerCapture140) Capture(values []string) error {
+	i.Val = values[0]
+	return nil
+}
+
+type outerCapture140 struct {
+	Inner innerCapture140 `@@`
+}
+
+// Types for TestCaptureCalledWithEmptySlice
+type emptyCapturableField struct {
+	Called bool
+	Val    string
+}
+
+func (e *emptyCapturableField) Capture(values []string) error {
+	e.Called = true
+	if len(values) > 0 {
+		e.Val = values[0]
+	}
+	return nil
+}
+
+type emptyCaptureGrammar struct {
+	Field emptyCapturableField `@Int?`
+	End   string               `@Ident`
+}
+
 func TestBoxedCapture(t *testing.T) {
 	lex := lexer.MustSimple([]lexer.SimpleRule{
 		{"Ident", `[a-zA-Z](\w|\.|/|:|-)*`},
@@ -1636,6 +1669,34 @@ func TestBoxedCapture(t *testing.T) {
 	if _, err := parser.ParseString("test", "abc::cdef.abc"); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestBoxedCaptureWithDoubleAt tests that a struct implementing Capture does not
+// panic when used with @@ (struct capture). Fixes #140.
+func TestBoxedCaptureWithDoubleAt(t *testing.T) {
+	parser := mustTestParser[outerCapture140](t, participle.UseLookahead(2))
+	ast, err := parser.ParseString("", "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", ast.Inner.Val)
+}
+
+// TestCaptureCalledWithEmptySlice verifies that when an optional capture doesn't
+// match, Capture is not invoked (consistent with old behavior: Defer is only
+// called when the inner node matches).
+func TestCaptureCalledWithEmptySlice(t *testing.T) {
+	parser := mustTestParser[emptyCaptureGrammar](t)
+	// No Int token before Ident → optional @Int? doesn't match → Capture not called.
+	ast, err := parser.ParseString("", "hello")
+	assert.NoError(t, err)
+	assert.False(t, ast.Field.Called, "Capture should not be called when optional doesn't match")
+	assert.Equal(t, "hello", ast.End)
+
+	// With Int token → Capture IS called.
+	ast, err = parser.ParseString("", "42 hello")
+	assert.NoError(t, err)
+	assert.True(t, ast.Field.Called, "Capture should be called when optional matches")
+	assert.Equal(t, "42", ast.Field.Val)
+	assert.Equal(t, "hello", ast.End)
 }
 
 func TestMatchEOF(t *testing.T) {


### PR DESCRIPTION
Fixes #140.

## Reproduction

```go
type Inner struct {
    Val string `@Ident`
}

func (i *Inner) Capture(values []string) error {
    i.Val = values[0]
    return nil
}

type Outer struct {
    Inner Inner `@@`
}

// Parsing any input panics:
// panic: interface conversion: interface {} is Inner, not string
```

## Root cause

In `setField()` (nodes.go), when a field's type implements the `Capture` interface, the code unconditionally asserts `v.Interface().(string)` on every element of `fieldValue`. When the field is populated via `@@` (struct capture), `fieldValue` contains parsed struct values — not strings — causing a type assertion panic.

## Fix

Before invoking `Capture()`, check whether `fieldValue` positively contains non-string values (`len(fieldValue) > 0 && fieldValue[0].Kind() != reflect.String`). Only then skip `Capture` and fall through to the struct-assignment path. In all other cases (empty values, string values), `Capture` is invoked exactly as before.

## When Capture is/isn't invoked

| Scenario | fieldValue | Capture called? | Before | After |
|----------|-----------|-----------------|--------|-------|
| `@Ident` matches | `["hello"]` | Yes | Yes | Yes (unchanged) |
| `@Ident?` doesn't match | Defer never called | No | No | No (unchanged) |
| `@@` (struct capture) | `[struct{...}]` | N/A | **panic** | No (field set directly) |
| Empty fieldValue (hypothetical) | `[]` | Yes | Yes | Yes (unchanged) |

## Compatibility

- Token captures (`@Ident`, `@Number`, etc.) with Capture types work exactly as before.
- Struct captures (`@@`) on Capture types now succeed instead of panicking; the struct is populated by the recursive parser as intended.
- No changes to exported API.

## Validation

- `TestBoxedCaptureWithDoubleAt`: regression test — panics on master, passes with fix.
- `TestCaptureCalledWithEmptySlice`: verifies Capture behavior is preserved for both matching and non-matching optional captures.
- `TestBoxedCapture` (existing): `@Ident` with Capture continues to pass.
- `go test ./...`: all package tests pass (one pre-existing infra failure in conformance tests unrelated to this change).
- `gofmt -l`: no formatting issues on touched files.