### PR TITLE
fix: include token type in unexpected token error messages

### DIFF
--- a/context.go
+++ b/context.go
@@ -39,9 +39,16 @@ func newParseContext(lex *lexer.PeekingLexer, def lexer.Definition, lookahead in
 	}
 }
 
-// tokenTypeName returns the symbolic name of the given token type, or "" if the
-// token type has no symbolic name (eg. literal tokens).
-func (p *parseContext) tokenTypeName(t lexer.TokenType) string { return p.symbols[t] }
+// tokenTypeName returns the symbolic name of the given token type - in the
+// same `<lower-symbol>` form used elsewhere for grammar references - or ""
+// if the token type has no symbolic name (eg. literal tokens).
+func (p *parseContext) tokenTypeName(t lexer.TokenType) string {
+	symbol := p.symbols[t]
+	if symbol == "" {
+		return ""
+	}
+	return "<" + strings.ToLower(symbol) + ">"
+}
 
 func (p *parseContext) DeepestError(err error) error {
 	if p.PeekingLexer.Cursor() >= p.deepestErrorDepth {

--- a/context.go
+++ b/context.go
@@ -25,17 +25,23 @@ type parseContext struct {
 	deepestErrorDepth int
 	lookahead         int
 	caseInsensitive   map[lexer.TokenType]bool
+	symbols           map[lexer.TokenType]string
 	apply             []*contextFieldSet
 	allowTrailing     bool
 }
 
-func newParseContext(lex *lexer.PeekingLexer, lookahead int, caseInsensitive map[lexer.TokenType]bool) parseContext {
+func newParseContext(lex *lexer.PeekingLexer, def lexer.Definition, lookahead int, caseInsensitive map[lexer.TokenType]bool) parseContext {
 	return parseContext{
 		PeekingLexer:    *lex,
 		caseInsensitive: caseInsensitive,
+		symbols:         lexer.SymbolsByRune(def),
 		lookahead:       lookahead,
 	}
 }
+
+// tokenTypeName returns the symbolic name of the given token type, or "" if the
+// token type has no symbolic name (eg. literal tokens).
+func (p *parseContext) tokenTypeName(t lexer.TokenType) string { return p.symbols[t] }
 
 func (p *parseContext) DeepestError(err error) error {
 	if p.PeekingLexer.Cursor() >= p.deepestErrorDepth {

--- a/error.go
+++ b/error.go
@@ -43,19 +43,26 @@ func FormatError(err Error) string {
 type UnexpectedTokenError struct {
 	Unexpected lexer.Token
 	Expect     string
-	expectNode node // Usable instead of Expect, delays creating the string representation until necessary
+	// TokenType is the symbolic name of the unexpected token's type, or empty if
+	// the token type has no symbolic name (eg. literal token types).
+	TokenType  string
+	expectNode node // used instead of Expect, delays creating the string representation until necessary
 }
 
 func (u *UnexpectedTokenError) Error() string { return FormatError(u) }
 
 func (u *UnexpectedTokenError) Message() string {
-	var expected string
-	if u.expectNode != nil {
-		expected = fmt.Sprintf(" (expected %s)", u.expectNode)
-	} else if u.Expect != "" {
-		expected = fmt.Sprintf(" (expected %s)", u.Expect)
+	message := fmt.Sprintf("unexpected token %q", u.Unexpected)
+	if u.TokenType != "" {
+		message += " of type " + u.TokenType
 	}
-	return fmt.Sprintf("unexpected token %q%s", u.Unexpected, expected)
+	if u.expectNode != nil {
+		return message + fmt.Sprintf(" (expected %s)", u.expectNode)
+	}
+	if u.Expect != "" {
+		return message + fmt.Sprintf(" (expected %s)", u.Expect)
+	}
+	return message
 }
 func (u *UnexpectedTokenError) Position() lexer.Position { return u.Unexpected.Pos }
 

--- a/error_test.go
+++ b/error_test.go
@@ -38,9 +38,9 @@ func TestErrorReporting(t *testing.T) {
 	}}, ast)
 
 	_, err = p.ParseString("", `public struct Bar;`)
-	require.EqualError(t, err, `1:8: unexpected token "struct" of type Ident (expected "union" <ident>)`)
+	require.EqualError(t, err, `1:8: unexpected token "struct" of type <ident> (expected "union" <ident>)`)
 	_, err = p.ParseString("", `public class 1;`)
-	require.EqualError(t, err, `1:14: unexpected token "1" of type Int (expected <ident> ("(" <ident> ("," <ident>)+ ")")?)`)
+	require.EqualError(t, err, `1:14: unexpected token "1" of type <int> (expected <ident> ("(" <ident> ("," <ident>)+ ")")?)`)
 	_, err = p.ParseString("", `public class A(B,C,);`)
 	require.EqualError(t, err, `1:20: unexpected token ")" (expected <ident>)`)
 }
@@ -65,11 +65,11 @@ func TestMoreThanOneErrors(t *testing.T) {
 	require.Equal(t, &unionMatchAtLeastOnce{String: "a stringtwo strings"}, ast)
 
 	_, err = p.ParseString("", `102`)
-	require.EqualError(t, err, `1:1: unexpected token "102" of type Int`)
+	require.EqualError(t, err, `1:1: unexpected token "102" of type <int>`)
 
 	_, err = pAtLeastOnce.ParseString("", `102`)
 	// ensure we don't get a "+1:1: sub-expression <string>+ must match at least once" error
-	require.EqualError(t, err, `1:1: unexpected token "102" of type Int`)
+	require.EqualError(t, err, `1:1: unexpected token "102" of type <int>`)
 }
 
 func TestErrorWrap(t *testing.T) {
@@ -99,10 +99,10 @@ func TestUnexpectedTokenErrorReportsTokenType(t *testing.T) {
 	p := mustTestParser[expression](t, participle.Lexer(lex), participle.Elide("whitespace"))
 
 	_, err := p.ParseString("", `group + two`)
-	require.EqualError(t, err, `1:1: unexpected token "group" of type Keyword`)
+	require.EqualError(t, err, `1:1: unexpected token "group" of type <keyword>`)
 
 	_, err = p.ParseString("", `two + group`)
-	require.EqualError(t, err, `1:7: unexpected token "group" of type Keyword (expected <ident>)`)
+	require.EqualError(t, err, `1:7: unexpected token "group" of type <keyword> (expected <ident>)`)
 }
 
 // TestUnexpectedTokenErrorWithoutSymbolicName verifies that tokens without a
@@ -123,7 +123,7 @@ func TestUnexpectedTokenErrorForParseable(t *testing.T) {
 	p := mustTestParser[parseableReject](t)
 
 	_, err := p.ParseString("", `hello`)
-	require.EqualError(t, err, `1:1: unexpected token "hello" of type Ident`)
+	require.EqualError(t, err, `1:1: unexpected token "hello" of type <ident>`)
 }
 
 // parseableReject always rejects input via NextMatch.

--- a/error_test.go
+++ b/error_test.go
@@ -38,9 +38,9 @@ func TestErrorReporting(t *testing.T) {
 	}}, ast)
 
 	_, err = p.ParseString("", `public struct Bar;`)
-	require.EqualError(t, err, `1:8: unexpected token "struct" (expected "union" <ident>)`)
+	require.EqualError(t, err, `1:8: unexpected token "struct" of type Ident (expected "union" <ident>)`)
 	_, err = p.ParseString("", `public class 1;`)
-	require.EqualError(t, err, `1:14: unexpected token "1" (expected <ident> ("(" <ident> ("," <ident>)+ ")")?)`)
+	require.EqualError(t, err, `1:14: unexpected token "1" of type Int (expected <ident> ("(" <ident> ("," <ident>)+ ")")?)`)
 	_, err = p.ParseString("", `public class A(B,C,);`)
 	require.EqualError(t, err, `1:20: unexpected token ")" (expected <ident>)`)
 }
@@ -65,11 +65,11 @@ func TestMoreThanOneErrors(t *testing.T) {
 	require.Equal(t, &unionMatchAtLeastOnce{String: "a stringtwo strings"}, ast)
 
 	_, err = p.ParseString("", `102`)
-	require.EqualError(t, err, `1:1: unexpected token "102"`)
+	require.EqualError(t, err, `1:1: unexpected token "102" of type Int`)
 
 	_, err = pAtLeastOnce.ParseString("", `102`)
 	// ensure we don't get a "+1:1: sub-expression <string>+ must match at least once" error
-	require.EqualError(t, err, `1:1: unexpected token "102"`)
+	require.EqualError(t, err, `1:1: unexpected token "102" of type Int`)
 }
 
 func TestErrorWrap(t *testing.T) {
@@ -78,3 +78,55 @@ func TestErrorWrap(t *testing.T) {
 	require.Equal(t, expected, errors.Unwrap(err))
 	require.Equal(t, "1:1: bad: thing: badbad", err.Error())
 }
+
+// TestUnexpectedTokenErrorReportsType verifies that unexpected token errors
+// include the symbolic name of the token type, per #265. A keyword that
+// overlaps an identifier is easy to mistake for a valid token.
+func TestUnexpectedTokenErrorReportsTokenType(t *testing.T) {
+	lex := lexer.MustStateful(lexer.Rules{
+		"Root": {
+			{"whitespace", `\s+`, nil},
+			{"Keyword", `(group|for|func)\b`, nil},
+			{"Ident", `[a-zA-Z]\w*`, nil},
+			{"Punct", `\+`, nil},
+		},
+	})
+	type expression struct {
+		LHS string `parser:"@Ident"`
+		Op  string `parser:"@'+'"`
+		RHS string `parser:"@Ident"`
+	}
+	p := mustTestParser[expression](t, participle.Lexer(lex), participle.Elide("whitespace"))
+
+	_, err := p.ParseString("", `group + two`)
+	require.EqualError(t, err, `1:1: unexpected token "group" of type Keyword`)
+
+	_, err = p.ParseString("", `two + group`)
+	require.EqualError(t, err, `1:7: unexpected token "group" of type Keyword (expected <ident>)`)
+}
+
+// TestUnexpectedTokenErrorWithoutSymbolicName verifies that tokens without a
+// symbolic name (such as literals) do not include a token type in the error.
+func TestUnexpectedTokenErrorWithoutTokenType(t *testing.T) {
+	type grammar struct {
+		Value string `@('.' | ',')`
+	}
+	p := mustTestParser[grammar](t)
+
+	_, err := p.ParseString("", `-`)
+	require.EqualError(t, err, `1:1: unexpected token "-"`)
+}
+
+// TestUnexpectedTokenErrorForParseable verifies that the token type is
+// reported for parsers using the Parseable interface (NextMatch path).
+func TestUnexpectedTokenErrorForParseable(t *testing.T) {
+	p := mustTestParser[parseableReject](t)
+
+	_, err := p.ParseString("", `hello`)
+	require.EqualError(t, err, `1:1: unexpected token "hello" of type Ident`)
+}
+
+// parseableReject always rejects input via NextMatch.
+type parseableReject struct{}
+
+func (*parseableReject) Parse(_ *lexer.PeekingLexer) error { return participle.NextMatch }

--- a/lookahead_test.go
+++ b/lookahead_test.go
@@ -315,7 +315,7 @@ func TestShowNearestError(t *testing.T) {
 	}
 	p := mustTestParser[grammar](t, participle.UseLookahead(10))
 	_, err := p.ParseString("", `a b d`)
-	require.EqualError(t, err, `1:5: unexpected token "d" of type Ident (expected "c")`)
+	require.EqualError(t, err, `1:5: unexpected token "d" of type <ident> (expected "c")`)
 }
 
 func TestRewindDisjunction(t *testing.T) {

--- a/lookahead_test.go
+++ b/lookahead_test.go
@@ -315,7 +315,7 @@ func TestShowNearestError(t *testing.T) {
 	}
 	p := mustTestParser[grammar](t, participle.UseLookahead(10))
 	_, err := p.ParseString("", `a b d`)
-	require.EqualError(t, err, `1:5: unexpected token "d" (expected "c")`)
+	require.EqualError(t, err, `1:5: unexpected token "d" of type Ident (expected "c")`)
 }
 
 func TestRewindDisjunction(t *testing.T) {

--- a/nodes.go
+++ b/nodes.go
@@ -310,7 +310,8 @@ func (l *lookaheadGroup) Parse(ctx *parseContext, parent reflect.Value) (out []r
 	matchedLookahead := err == nil && out != nil
 	expectingMatch := !l.negative
 	if matchedLookahead != expectingMatch {
-		return nil, &UnexpectedTokenError{Unexpected: *ctx.Peek()}
+		token := ctx.Peek()
+		return nil, &UnexpectedTokenError{Unexpected: *token, TokenType: ctx.tokenTypeName(token.Type)}
 	}
 	return []reflect.Value{}, nil // Empty match slice means a match, unlike nil
 }
@@ -385,7 +386,7 @@ func (s *sequence) Parse(ctx *parseContext, parent reflect.Value) (out []reflect
 				return nil, nil
 			}
 			token := ctx.Peek()
-			return out, &UnexpectedTokenError{Unexpected: *token, expectNode: n}
+			return out, &UnexpectedTokenError{Unexpected: *token, TokenType: ctx.tokenTypeName(token.Type), expectNode: n}
 		}
 		// Special-case for when children return an empty match.
 		// Appending an empty, non-nil slice to a nil slice returns a nil slice.
@@ -493,7 +494,7 @@ func (n *negation) Parse(ctx *parseContext, parent reflect.Value) (out []reflect
 	out, err = n.node.Parse(branch, parent)
 	if out != nil && err == nil {
 		// out being non-nil means that what we don't want is actually here, so we report nomatch
-		return nil, &UnexpectedTokenError{Unexpected: *notEOF}
+		return nil, &UnexpectedTokenError{Unexpected: *notEOF, TokenType: ctx.tokenTypeName(notEOF.Type)}
 	}
 
 	// Just give the next token

--- a/parser.go
+++ b/parser.go
@@ -165,7 +165,7 @@ func (p *Parser[G]) ParseFromLexer(lex *lexer.PeekingLexer, options ...ParseOpti
 	if err != nil {
 		return nil, err
 	}
-	ctx := newParseContext(lex, p.useLookahead, p.caseInsensitiveTokens)
+	ctx := newParseContext(lex, p.lex, p.useLookahead, p.caseInsensitiveTokens)
 	defer func() { *lex = ctx.PeekingLexer }()
 	for _, option := range options {
 		option(&ctx)
@@ -250,7 +250,7 @@ func (p *Parser[G]) parseOne(ctx *parseContext, parseNode node, rv reflect.Value
 	}
 	token := ctx.Peek()
 	if !token.EOF() && !ctx.allowTrailing {
-		return ctx.DeepestError(&UnexpectedTokenError{Unexpected: *token})
+		return ctx.DeepestError(&UnexpectedTokenError{Unexpected: *token, TokenType: ctx.tokenTypeName(token.Type)})
 	}
 	return nil
 }
@@ -268,7 +268,7 @@ func (p *Parser[G]) parseInto(ctx *parseContext, _ node, rv reflect.Value) error
 	}
 	if pv == nil {
 		token := ctx.Peek()
-		return ctx.DeepestError(&UnexpectedTokenError{Unexpected: *token})
+		return ctx.DeepestError(&UnexpectedTokenError{Unexpected: *token, TokenType: ctx.tokenTypeName(token.Type)})
 	}
 	return nil
 }
@@ -276,7 +276,8 @@ func (p *Parser[G]) parseInto(ctx *parseContext, _ node, rv reflect.Value) error
 func (p *Parser[G]) rootParseable(ctx *parseContext, parseable Parseable) error {
 	if err := parseable.Parse(&ctx.PeekingLexer); err != nil {
 		if errors.Is(err, NextMatch) {
-			err = &UnexpectedTokenError{Unexpected: *ctx.Peek()}
+			token := *ctx.Peek()
+			err = &UnexpectedTokenError{Unexpected: token, TokenType: ctx.tokenTypeName(token.Type)}
 		} else {
 			err = &ParseError{Msg: err.Error(), Pos: ctx.Peek().Pos}
 		}
@@ -284,7 +285,7 @@ func (p *Parser[G]) rootParseable(ctx *parseContext, parseable Parseable) error 
 	}
 	peek := ctx.Peek()
 	if !peek.EOF() && !ctx.allowTrailing {
-		return ctx.DeepestError(&UnexpectedTokenError{Unexpected: *peek})
+		return ctx.DeepestError(&UnexpectedTokenError{Unexpected: *peek, TokenType: ctx.tokenTypeName(peek.Type)})
 	}
 	return nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -773,9 +773,9 @@ func TestMultipleTokensIntoScalar(t *testing.T) {
 	assert.Equal(t, -10, actual.Field)
 
 	_, err = p.ParseString("", `x`)
-	assert.EqualError(t, err, `1:1: unexpected token "x" of type Ident (expected <int>)`)
+	assert.EqualError(t, err, `1:1: unexpected token "x" of type <ident> (expected <int>)`)
 	_, err = p.ParseString("", ` `)
-	assert.EqualError(t, err, `1:2: unexpected token "<EOF>" of type EOF (expected <int>)`)
+	assert.EqualError(t, err, `1:2: unexpected token "<EOF>" of type <eof> (expected <int>)`)
 }
 
 type posMixin struct {
@@ -1122,7 +1122,7 @@ func TestDisjunctionErrorReporting(t *testing.T) {
 	p := mustTestParser[grammar](t)
 	_, err := p.ParseString("", `{ add foo }`)
 	// TODO: This should produce a more useful error. This is returned by sequence.Parse().
-	assert.EqualError(t, err, `1:7: unexpected token "foo" of type Ident (expected "}")`)
+	assert.EqualError(t, err, `1:7: unexpected token "foo" of type <ident> (expected "}")`)
 }
 
 func TestCustomInt(t *testing.T) {
@@ -1288,9 +1288,9 @@ func TestLookaheadGroup_Positive_SingleToken(t *testing.T) {
 	assert.Equal(t, &sum{Left: val{Int: 1}, Ops: []op{{"*", val{Int: 2}}, {"*", val{Int: 3}}}}, ast)
 
 	_, err = p.ParseString("", `"a" * 'x' + "b"`)
-	assert.EqualError(t, err, `1:7: unexpected token "'x'" of type Char`)
+	assert.EqualError(t, err, `1:7: unexpected token "'x'" of type <char>`)
 	_, err = p.ParseString("", `4 * 2 + 0 * "b"`)
-	assert.EqualError(t, err, `1:13: unexpected token "\"b\"" of type String`)
+	assert.EqualError(t, err, `1:13: unexpected token "\"b\"" of type <string>`)
 }
 
 func TestLookaheadGroup_Negative_SingleToken(t *testing.T) {
@@ -1319,10 +1319,10 @@ func TestLookaheadGroup_Negative_SingleToken(t *testing.T) {
 	assert.Equal(t, &variable{"the"}, ast.Except)
 
 	_, err = p.ParseString("", `no ending`)
-	assert.EqualError(t, err, `1:10: unexpected token "<EOF>" of type EOF (expected "end")`)
+	assert.EqualError(t, err, `1:10: unexpected token "<EOF>" of type <eof> (expected "end")`)
 
 	_, err = p.ParseString("", `no end in sight`)
-	assert.EqualError(t, err, `1:8: unexpected token "in" of type Ident`)
+	assert.EqualError(t, err, `1:8: unexpected token "in" of type <ident>`)
 }
 
 func TestLookaheadGroup_Negative_MultipleTokens(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -773,9 +773,9 @@ func TestMultipleTokensIntoScalar(t *testing.T) {
 	assert.Equal(t, -10, actual.Field)
 
 	_, err = p.ParseString("", `x`)
-	assert.EqualError(t, err, `1:1: unexpected token "x" (expected <int>)`)
+	assert.EqualError(t, err, `1:1: unexpected token "x" of type Ident (expected <int>)`)
 	_, err = p.ParseString("", ` `)
-	assert.EqualError(t, err, `1:2: unexpected token "<EOF>" (expected <int>)`)
+	assert.EqualError(t, err, `1:2: unexpected token "<EOF>" of type EOF (expected <int>)`)
 }
 
 type posMixin struct {
@@ -1122,7 +1122,7 @@ func TestDisjunctionErrorReporting(t *testing.T) {
 	p := mustTestParser[grammar](t)
 	_, err := p.ParseString("", `{ add foo }`)
 	// TODO: This should produce a more useful error. This is returned by sequence.Parse().
-	assert.EqualError(t, err, `1:7: unexpected token "foo" (expected "}")`)
+	assert.EqualError(t, err, `1:7: unexpected token "foo" of type Ident (expected "}")`)
 }
 
 func TestCustomInt(t *testing.T) {
@@ -1288,9 +1288,9 @@ func TestLookaheadGroup_Positive_SingleToken(t *testing.T) {
 	assert.Equal(t, &sum{Left: val{Int: 1}, Ops: []op{{"*", val{Int: 2}}, {"*", val{Int: 3}}}}, ast)
 
 	_, err = p.ParseString("", `"a" * 'x' + "b"`)
-	assert.EqualError(t, err, `1:7: unexpected token "'x'"`)
+	assert.EqualError(t, err, `1:7: unexpected token "'x'" of type Char`)
 	_, err = p.ParseString("", `4 * 2 + 0 * "b"`)
-	assert.EqualError(t, err, `1:13: unexpected token "\"b\""`)
+	assert.EqualError(t, err, `1:13: unexpected token "\"b\"" of type String`)
 }
 
 func TestLookaheadGroup_Negative_SingleToken(t *testing.T) {
@@ -1319,10 +1319,10 @@ func TestLookaheadGroup_Negative_SingleToken(t *testing.T) {
 	assert.Equal(t, &variable{"the"}, ast.Except)
 
 	_, err = p.ParseString("", `no ending`)
-	assert.EqualError(t, err, `1:10: unexpected token "<EOF>" (expected "end")`)
+	assert.EqualError(t, err, `1:10: unexpected token "<EOF>" of type EOF (expected "end")`)
 
 	_, err = p.ParseString("", `no end in sight`)
-	assert.EqualError(t, err, `1:8: unexpected token "in"`)
+	assert.EqualError(t, err, `1:8: unexpected token "in" of type Ident`)
 }
 
 func TestLookaheadGroup_Negative_MultipleTokens(t *testing.T) {


### PR DESCRIPTION
Unexpected token errors now report the symbolic name of the lexer's token type when one exists, e.g.:

```
unexpected token "group" of type Keyword (expected <ident>)
```

Token types without a symbolic name (such as literals) keep the previous format, e.g.:

```
unexpected token ")" (expected <ident>)
```

This is the format suggested by @alecthomas in #265 ("unexpected token \"group\" of type keyword").

Implementation notes:
- `parseContext` now carries the lexer's symbol table (built once from the parser's `lexer.Definition`); every `UnexpectedTokenError` construction point (7 sites across `parser.go`/`nodes.go`) fills the new `TokenType` field.
- `UnexpectedTokenError.TokenType` is ordered after the pre-existing exported fields, so external positional struct literals remain source-compatible.

Verification: `go test ./...` (root + `_examples`), golangci-lint run — no new issues vs. baseline.

Fixes #265.