### PR TITLE
fix: handle unmatched optional capture groups in stateful lexer actions

### DIFF
--- a/lexer/stateful.go
+++ b/lexer/stateful.go
@@ -404,7 +404,13 @@ next:
 		if rule.Action != nil {
 			groups := make([]string, 0, len(match)/2)
 			for i := 0; i < len(match); i += 2 {
-				groups = append(groups, l.data[match[i]:match[i+1]])
+				// Optional capture groups may not match; regexp returns -1 for
+				// those, so pass them to actions as an empty string.
+				if match[i] >= 0 {
+					groups = append(groups, l.data[match[i]:match[i+1]])
+				} else {
+					groups = append(groups, "")
+				}
 			}
 			if err := rule.Action.applyAction(l, groups); err != nil {
 				return Token{}, errorf(l.pos, "lexer: rule %q: %s", rule.Name, err)

--- a/lexer/stateful_test.go
+++ b/lexer/stateful_test.go
@@ -174,6 +174,32 @@ func TestStatefulLexer(t *testing.T) {
 			input: "hello",
 			err:   "1:1: lexer: rule \"NoMatch\": did not consume any input",
 		},
+		{name: "UnmatchedOptionalCaptureGroup",
+			// An optional capture group that does not match must not cause a
+			// panic (issue #324); it is passed to actions as an empty string.
+			rules: lexer.Rules{
+				"Root": {
+					{"Ident", `[a-z]([a-z])?`, lexer.Push("Inner")},
+				},
+				"Inner": {
+					{"Ident", `[a-z]([a-z])?`, lexer.Pop()},
+				},
+			},
+			input:  `a`,
+			tokens: []string{"a"},
+		},
+		{name: "BackrefMatchesEmptyCaptureGroup",
+			rules: lexer.Rules{
+				"Root": {
+					{"A", `(a)?b`, lexer.Push("Next")},
+				},
+				"Next": {
+					{"C", `\1c`, nil},
+				},
+			},
+			input:  `bc`,
+			tokens: []string{"b", "c"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
When a stateful lexer rule has an optional capture group that does not match (e.g. `[a-z]([a-z])?` matching `"a"`), `regexp.FindStringSubmatchIndex` reports it with indices of `-1`. Building the groups passed to `Action`s sliced the input with those indices, panicking with `slice bounds out of range`.

The reported `%x + y` case from #324 is a real-world instance: the keyword/Ident design pushes a state on `%`, and the next rule's action (`Pop`) crashed on the unmatched capture group.

Changes:
- `lexer/stateful.go`: unmatched capture groups are passed to actions as empty strings instead of panicking. Keeping the group position (rather than dropping it) also preserves the meaning of `\n` backreferences to later states — an unmatched group genuinely captures the empty string.
- `lexer/stateful_test.go`: two new table cases — "UnmatchedOptionalCaptureGroup" (panics before this fix, per #324) and "BackrefMatchesEmptyCaptureGroup" (exercises the parent-state group hand-off).

Verification: `go test ./...` (root + `_examples`) green; golangci-lint — no new issues.

Fixes #324.