### PR TITLE
fix(ebnf): emit token references for parseable/custom productions so railroad diagrams render

### DIFF
--- a/cmd/railroad/main.go
+++ b/cmd/railroad/main.go
@@ -104,8 +104,10 @@ h1 {
 		}
 		switch {
 		case n.Name != "":
-			p := productions[n.Name]
-			if p.refs > mergeRefThreshold {
+			p, ok := productions[n.Name]
+			if !ok {
+				s += fmt.Sprintf("NonTerminal(%q)", n.Name)
+			} else if p.refs > mergeRefThreshold {
 				s += fmt.Sprintf("NonTerminal(%q, {href:\"#%s\"})", n.Name, n.Name)
 			} else {
 				s += generate(productions, p.Expression)
@@ -165,8 +167,10 @@ func countProductions(productions map[string]*production, n ebnf.Node) (size int
 		}
 	case *ebnf.Term:
 		if n.Name != "" {
-			productions[n.Name].refs++
-			size++
+			if p, ok := productions[n.Name]; ok {
+				p.refs++
+				size++
+			}
 		} else if n.Group != nil {
 			size += countProductions(productions, n.Group)
 		} else {

--- a/ebnf.go
+++ b/ebnf.go
@@ -70,8 +70,8 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 		}
 
 	case *custom:
-		name := strings.ToUpper(n.typ.Name()[:1]) + n.typ.Name()[1:]
-		p.out += name
+		// Custom types have no parseable structure, so signal them as a token reference.
+		p.out += "<" + strings.ToLower(n.typ.Name()) + ">"
 
 	case *strct:
 		name := strings.ToUpper(n.typ.Name()[:1]) + n.typ.Name()[1:]
@@ -103,7 +103,9 @@ func buildEBNF(root bool, n node, seen map[node]bool, p *ebnfp, outp *[]*ebnfp) 
 		}
 
 	case *parseable:
-		p.out += n.t.Name()
+		// Parseable productions are handled externally, so a token reference to
+		// the production name is the best we can do.
+		p.out += "<" + strings.ToLower(n.t.Name()) + ">"
 
 	case *capture:
 		buildEBNF(false, n.node, seen, p, outp)

--- a/ebnf_test.go
+++ b/ebnf_test.go
@@ -6,6 +6,7 @@ import (
 
 	require "github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
 )
 
 func TestEBNF(t *testing.T) {
@@ -74,4 +75,19 @@ EBNFUnionB = <string> .
 EBNFUnionC = <float> .
 `),
 		parser.String())
+}
+
+type (
+	EBNFParseable struct{}
+
+	EBNFParseableGrammar struct {
+		V EBNFParseable `@@`
+	}
+)
+
+func (EBNFParseable) Parse(_ *lexer.PeekingLexer) error { return participle.NextMatch }
+
+func TestEBNF_Parseable(t *testing.T) {
+	parser := mustTestParser[EBNFParseableGrammar](t)
+	require.Equal(t, `EBNFParseableGrammar = <ebnfparseable> .`, parser.String())
 }

--- a/grammar.go
+++ b/grammar.go
@@ -66,10 +66,7 @@ func (g *generatorContext) parseType(t reflect.Type) (_ node, returnedError erro
 		}
 		return n, nil
 	}
-	if t.Implements(parseableType) {
-		return &parseable{t.Elem()}, nil
-	}
-	if reflect.PointerTo(t).Implements(parseableType) {
+	if t.Implements(parseableType) || reflect.PointerTo(t).Implements(parseableType) {
 		return &parseable{t}, nil
 	}
 	switch t.Kind() { //nolint:exhaustive // explicit kinds handled

--- a/parser_test.go
+++ b/parser_test.go
@@ -1775,7 +1775,7 @@ func TestParserWithCustomProduction(t *testing.T) {
 		assert.Equal(t, c.expected, actual.Custom)
 	}
 
-	assert.Equal(t, `Grammar = TestCustom .`, p.String())
+	assert.Equal(t, `Grammar = <testcustom> .`, p.String())
 }
 
 type (


### PR DESCRIPTION
Fixes #444.

## Problem

For grammars using the `Parseable` interface (e.g. [langx](https://github.com/alecthomas/langx)'s operator-precedence approach), `parser.String()` produced EBNF referencing undeclared uppercase productions, and `cmd/railroad` crashed with a nil pointer dereference on the missing production entry:

```
panic: runtime error: invalid memory address or nil pointer dereference
main.countProductions ... (productions[n.Name].refs++ on a missing key)
```

## Fix

- `ebnf.go`: `*parseable` and `*custom` nodes now emit token references (`<custom>`) instead of a bare undeclared type name (`Custom`), consistent with the EBNF invariant (uppercase = production, lowercase = lexer token). These are not real lexer tokens at runtime, but they are the only renderable representation of an externally-parsed production.
- `grammar.go`: value-receiver implementations of `Parseable` (e.g. `func (Modifier) Parse(...)`) panicked with `reflect: Elem of invalid type` in `parseType` because `t.Elem()` was unconditionally called on a non-pointer type. Now handled uniformly.
- `cmd/railroad/main.go`: nil-guarded `productions[n.Name]` lookups in both `countProductions` and `generate`, so third-party EBNF with unresolved references renders instead of panicking.

## Example

Before this PR these EBNF lines would crash `cmd/railroad`; now they render:

```
Root = <modifier> Body .
Body = <ident> <custom> .
```

One test assertion updated (`TestParserWithCustomProduction`), and one EBNF test added using a value-receiver `Parseable` (`TestEBNF_Parseable`) covering both bugs.

Note this is a breaking change to `parser.String()` output for grammars with parseable/custom productions.