### PR TITLE
fix: don't panic when capturing into struct types that implement Capture

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -627,9 +627,12 @@ func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField,
 
 	if f.CanAddr() {
 		if d, ok := f.Addr().Interface().(Capture); ok {
-			ifv := make([]string, 0, len(fieldValue))
-			for _, v := range fieldValue {
-				ifv = append(ifv, v.Interface().(string))
+			if len(fieldValue) > 0 && fieldValue[0].Type().AssignableTo(f.Type()) {
+				f.Set(fieldValue[0])
+			}
+			ifv := make([]string, 0, len(tokens))
+			for _, t := range tokens {
+				ifv = append(ifv, t.Value)
 			}
 			err = d.Capture(ifv)
 			if err != nil {
@@ -637,10 +640,18 @@ func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField,
 			}
 			return nil
 		} else if d, ok := f.Addr().Interface().(encoding.TextUnmarshaler); ok {
-			for _, v := range fieldValue {
-				if err := d.UnmarshalText([]byte(v.Interface().(string))); err != nil {
-					return Wrapf(pos, err, "failed to unmarshal text")
+			if len(fieldValue) > 0 && fieldValue[0].Type().AssignableTo(f.Type()) {
+				f.Set(fieldValue[0])
+			}
+			text := make([]byte, 0, 64)
+			for i, t := range tokens {
+				if i > 0 {
+					text = append(text, ' ')
 				}
+				text = append(text, t.Value...)
+			}
+			if err := d.UnmarshalText(text); err != nil {
+				return Wrapf(pos, err, "failed to unmarshal text")
 			}
 			return nil
 		}
@@ -652,9 +663,15 @@ func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField,
 			if sliceElemType.Kind() == reflect.Pointer {
 				sliceElemType = sliceElemType.Elem()
 			}
-			for _, v := range fieldValue {
+			for i, v := range fieldValue {
 				d := reflect.New(sliceElemType).Interface().(Capture)
-				if err := d.Capture([]string{v.Interface().(string)}); err != nil {
+				t := ""
+				if v.Kind() == reflect.String {
+					t = v.String()
+				} else if i < len(tokens) {
+					t = tokens[i].Value
+				}
+				if err := d.Capture([]string{t}); err != nil {
 					return Wrapf(pos, err, "failed to capture")
 				}
 				eltValue := reflect.ValueOf(d)

--- a/parser_test.go
+++ b/parser_test.go
@@ -1779,6 +1779,51 @@ func TestParserWithCustomProduction(t *testing.T) {
 }
 
 type (
+	StructCaptureGrammar struct {
+		Pos   lexer.Position
+		Boxes StructCaptureBox `@@`
+	}
+
+	StructCaptureBox struct {
+		Pos lexer.Position
+		Val string `@Ident`
+	}
+)
+
+func (b *StructCaptureBox) Capture(values []string) error {
+	b.Val = values[0]
+	return nil
+}
+
+func TestStructCaptureViaExpression(t *testing.T) {
+	parser := mustTestParser[StructCaptureGrammar](t)
+	boxed, err := parser.ParseString("test", "abc")
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", boxed.Boxes.Val)
+}
+
+type (
+	StructUnmarshalGrammar struct {
+		Pos lexer.Position
+		U   StructUnmarshalText `@@`
+	}
+
+	StructUnmarshalText struct {
+		Pos lexer.Position
+		Val string `@String`
+	}
+)
+
+func (u *StructUnmarshalText) UnmarshalText(_ []byte) error { return nil }
+
+func TestStructCaptureWithTextUnmarshaler(t *testing.T) {
+	parser := mustTestParser[StructUnmarshalGrammar](t)
+	boxed, err := parser.ParseString("test", `"abc"`)
+	assert.NoError(t, err)
+	assert.Equal(t, `"abc"`, boxed.U.Val)
+}
+
+type (
 	TestUnionA interface{ isTestUnionA() }
 	TestUnionB interface{ isTestUnionB() }
 


### PR DESCRIPTION
Fixes #140.

## Problem

A struct that implements `Capture` (or `encoding.TextUnmarshaler`) and is captured with `@@` panicked at runtime:

```
panic: interface conversion: interface {} is parser.Box, not string
```

`setField` built the `values []string` argument from converted reflect values of the already-parsed struct, so `v.Interface().(string)` was a hard type assertion on a `Box` struct value.

## Fix

- `Capture` is now fed from the **raw token values**, which is what the `Capture` contract actually expects (`values []string`): `node.Parse` collects token values in order, so `values[0]` is the captured token text.
- When the parsed field value is assignable to the field (e.g. a `@@` struct that also implements `Capture`), it is pre-assigned so `Pos`/other already-parsed fields are kept.
- The `encoding.TextUnmarshaler` path was equally broken for struct types; it now unmarshals the joined token text (and keeps the parsed struct value).
- Slice captures keep passing plain string values unchanged.

## Example (from the issue)

```go
parser.ParseString("test", "abc::cdef.abc", &Boxes{})
// Boxes.Boxes.Val == "abc::cdef.abc"  (previously: panic)
```

Two new tests: `TestStructCaptureViaExpression`, `TestStructCaptureWithTextUnmarshaler`. The existing `TestBoxedCapture`/`TestCaptureOnSliceElements` continue to pass.