### PR TITLE
fix(lexer): validate rule names are valid Go identifiers

### DIFF
--- a/lexer/stateful.go
+++ b/lexer/stateful.go
@@ -238,11 +238,23 @@ func MustStateful(rules Rules) *StatefulDefinition {
 	return def
 }
 
+func isValidIdent(name string) bool {
+	for i, r := range name {
+		if r != '_' && !unicode.IsLetter(r) && (i == 0 || !unicode.IsDigit(r)) {
+			return false
+		}
+	}
+	return true
+}
+
 // New constructs a new stateful lexer from rules.
 func New(rules Rules) (*StatefulDefinition, error) {
 	compiled := compiledRules{}
 	for key, set := range rules {
 		for i, rule := range set {
+			if rule.Name != "" && !isValidIdent(rule.Name) {
+				return nil, fmt.Errorf("lexer: %s.%d: invalid rule name %q: must be a valid Go identifier", key, i, rule.Name)
+			}
 			if validate, ok := rule.Action.(validatingRule); ok {
 				if err := validate.validate(rules); err != nil {
 					return nil, fmt.Errorf("lexer: invalid action for rule %q: %w", rule.Name, err)

--- a/lexer/stateful_test.go
+++ b/lexer/stateful_test.go
@@ -335,6 +335,21 @@ func TestStateful(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestInvalidRuleName(t *testing.T) {
+	for _, name := range []string{"match:", "match;", "1two", "has space", "ünïcode-rune"} {
+		_, err := lexer.New(lexer.Rules{
+			"Root": {{Name: name, Pattern: `x`}},
+		})
+		require.Error(t, err, "rule name %q must be rejected", name)
+	}
+	for _, name := range []string{"Ident", "identifier", "_private", "ünïcode"} {
+		_, err := lexer.New(lexer.Rules{
+			"Root": {{Name: name, Pattern: `x`}},
+		})
+		require.NoError(t, err, "rule name %q must be accepted", name)
+	}
+}
+
 func TestHereDoc(t *testing.T) {
 	type Heredoc struct {
 		Idents []string `Heredoc @Ident* End`


### PR DESCRIPTION
Closes #202

Rule names are interpolated verbatim into generated codegen function names (`match<Lexer><Rule>`), so invalid identifiers such as `match:`, `;`, `|` or `@` produced uncompilable source (see #202 for the original report).

Rather than escaping names in codegen (which would silently rename tokens behind the parser's back), this validates at `lexer.New` construction time — the earliest point where a malformed name can be caught, and consistent with @alecthomas's assessment: "they are not valid rule names as only identifiers can be matched by the parser. This is really a validation error."

Changes:
- `lexer/stateful.go`: reject non-identifier rule names in `New()` with a clear error (`lexer: <state>.<idx>: invalid rule name ...`)
- `lexer/stateful_test.go`: table test covering invalid (`match:`, `;`, `1two`, `has space`, `ünïcode-rune`) and valid (`Ident`, `identifier`, `_private`, `ünïcode`) names

No behavior change for existing valid lexers; names that were never usable now fail fast instead of emitting broken codegen output.