### PR TITLE
feat: add fuzzing example and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,27 @@ thrift takes 630ms, which aligns quite closely with the benchmarks.
 
 A compiled `Parser` instance can be used concurrently. A `LexerDefinition` can be used concurrently. A `Lexer` instance cannot be used concurrently.
 
+## Fuzzing
+
+Participle parsers are well suited to Go's native fuzzing. Because a grammar is just a struct, a fuzz target can be written in a few lines and will exercise the parser, lexer and grammar-recursion machinery with arbitrary input, catching panics, hangs and pathological inputs:
+
+```go
+func FuzzParse(f *testing.F) {
+	parser, err := participle.Build[grammar]()
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, seed := range []string{"1+2", "", "(", "\xff"} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		_, _ = parser.ParseString("", in)
+	})
+}
+```
+
+Run with `go test -fuzz=FuzzParse -fuzztime 30s ./...` (the seeds run as a regular test, so the target is also safe to commit and run in CI). A ready-to-run example is included in `fuzz_test.go`.
+
 ## Error reporting
 
 There are a few areas where Participle can provide useful feedback to users of your parser.

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,40 @@
+package participle_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/participle/v2"
+)
+
+// FuzzParse exercises the participle parser itself with arbitrary input,
+// ensuring that no grammar panics or hangs on malformed input.
+//
+// Run with: go test -fuzz=FuzzParse -fuzztime 30s ./...
+func FuzzParse(f *testing.F) {
+	type grammar struct {
+		Expr struct {
+			Left  int      `@Int`
+			Op    string   `@("+" | "-" | "*" | "/")`
+			Right []int    `(@Int)*`
+		} `@@`
+	}
+	parser, err := participle.Build[grammar]()
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, seed := range []string{
+		"1+2",
+		"",
+		"(",
+		"1 / 0",
+		"\xff\xfe",
+		"abc",
+		"1+-2*3/4",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		//nolint:errcheck // err is the expected outcome of fuzzing.
+		_, _ = parser.ParseString("", in)
+	})
+}


### PR DESCRIPTION
Partially addresses #204

Grammar-driven generation (`parser.Fuzz(&ast)` producing random *valid* strings) would be a larger project — it needs a regex-to-string generator in the lexer to invert captures. This PR instead delivers the immediately useful half of the request: an official, ready-to-run native Go fuzz target for participle parsers.

Changes:
- `fuzz_test.go`: `FuzzParse` — a concrete example target that exercises a grammar with arbitrary input (panic/hang detection), with a seed corpus that also runs in CI as a regular test
- `README.md`: new "Fuzzing" section explaining the pattern and usage (`go test -fuzz=FuzzParse -fuzztime 30s ./...`)

If grammar-driven generation is still desired, it would fit well as a separate issue with a design for a `lexer.Pattern` → string generator.