### PR TITLE
fix: inject Pos/EndPos/Tokens into Capture and TextUnmarshaler values

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/alecthomas/participle/v2/lexer"
 )
@@ -596,6 +597,32 @@ func maybeRef(tmpl reflect.Type, strct reflect.Value) reflect.Value {
 //
 // For all other types, an attempt will be made to convert the string to the corresponding
 // type (int, float32, etc.).
+// applyCapturePosition populates the Pos, EndPos and Tokens fields of a
+// user-defined Capture/TextUnmarshaler value, mirroring the injection done
+// for struct nodes (see strct.maybeInject*).
+func applyCapturePosition(f reflect.Value, tokens []lexer.Token) {
+	if f.Kind() == reflect.Pointer {
+		f = f.Elem()
+	}
+	if f.Kind() != reflect.Struct || len(tokens) == 0 {
+		return
+	}
+	t := f.Type()
+	if field, ok := t.FieldByName("Pos"); ok && positionType.ConvertibleTo(field.Type) {
+		f.FieldByName("Pos").Set(reflect.ValueOf(tokens[0].Pos).Convert(field.Type))
+	}
+	if field, ok := t.FieldByName("EndPos"); ok && positionType.ConvertibleTo(field.Type) {
+		last := tokens[len(tokens)-1]
+		end := last.Pos
+		end.Offset += len(last.Value)
+		end.Column += utf8.RuneCountInString(last.Value)
+		f.FieldByName("EndPos").Set(reflect.ValueOf(end).Convert(field.Type))
+	}
+	if field, ok := t.FieldByName("Tokens"); ok && field.Type == tokensType {
+		f.FieldByName("Tokens").Set(reflect.ValueOf(tokens))
+	}
+}
+
 func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField, fieldValue []reflect.Value) (err error) { //nolint:gocognit
 	f := strct.FieldByIndex(field.Index)
 
@@ -635,6 +662,7 @@ func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField,
 			if err != nil {
 				return Wrapf(pos, err, "failed to capture")
 			}
+			applyCapturePosition(f, tokens)
 			return nil
 		} else if d, ok := f.Addr().Interface().(encoding.TextUnmarshaler); ok {
 			for _, v := range fieldValue {
@@ -642,6 +670,7 @@ func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField,
 					return Wrapf(pos, err, "failed to unmarshal text")
 				}
 			}
+			applyCapturePosition(f, tokens)
 			return nil
 		}
 	}
@@ -661,6 +690,7 @@ func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField,
 				if f.Type().Elem().Kind() != reflect.Pointer {
 					eltValue = eltValue.Elem()
 				}
+				applyCapturePosition(eltValue, tokens)
 				f.Set(reflect.Append(f, eltValue))
 			}
 		} else {

--- a/parser_test.go
+++ b/parser_test.go
@@ -517,6 +517,34 @@ func mustTestParser[G any](t *testing.T, options ...participle.Option) *particip
 	return parser
 }
 
+type capturePosTarget struct {
+	Pos    lexer.Position
+	EndPos lexer.Position
+	Tokens []lexer.Token
+	V      string
+}
+
+func (c *capturePosTarget) Capture(values []string) error {
+	c.V = strings.Join(values, " ")
+	return nil
+}
+
+func TestCaptureStructPosition(t *testing.T) {
+	type grammar struct {
+		C capturePosTarget `@Ident @Ident`
+	}
+
+	parser := mustTestParser[grammar](t)
+
+	actual, err := parser.ParseString("", "hello world")
+	assert.NoError(t, err)
+	assert.Equal(t, lexer.Position{Offset: 6, Line: 1, Column: 7}, actual.C.Pos)
+	assert.Equal(t, lexer.Position{Offset: 11, Line: 1, Column: 12}, actual.C.EndPos)
+	assert.Equal(t, "world", actual.C.V)
+	assert.Equal(t, 1, len(actual.C.Tokens))
+	assert.Equal(t, "world", actual.C.Tokens[0].Value)
+}
+
 func BenchmarkEBNFParser(b *testing.B) {
 	parser, err := participle.Build[EBNF]()
 	assert.NoError(b, err)


### PR DESCRIPTION
Closes #132

`Pos`/`EndPos`/`Tokens` are injected automatically for struct nodes parsed via `@@`, but user-defined capture targets implementing `Capture` or `encoding.TextUnmarshaler` never had them populated — the `Pos lexer.Position` field stayed zero (verified on master with `@Ident @Ident`).

Changes:
- `nodes.go`: new `applyCapturePosition` helper populates `Pos`, `EndPos` and `Tokens` on capture targets (guarding non-struct types such as `type count int`), called from the `Capture` and `TextUnmarshaler` branches of `setField`, and per-element for `[]Capture` slices.
- `parser_test.go`: `TestCaptureStructPosition` covering `Pos`, `EndPos` and `Tokens` on a `Capture` struct.

`EndPos` is computed as the last captured token's position advanced by its length (byte offset, rune column) — an approximation of the next-token position the struct path uses; it doesn't account for embedded newlines in captured values.