### PR TITLE
feat: add RecoverTo option for fault-tolerant parsing

### DIFF
--- a/context.go
+++ b/context.go
@@ -27,6 +27,9 @@ type parseContext struct {
 	caseInsensitive   map[lexer.TokenType]bool
 	apply             []*contextFieldSet
 	allowTrailing     bool
+	recovery          []recoverNode
+	structural        map[string]bool
+	lastRecovery      lexer.RawCursor
 }
 
 func newParseContext(lex *lexer.PeekingLexer, lookahead int, caseInsensitive map[lexer.TokenType]bool) parseContext {

--- a/nodes.go
+++ b/nodes.go
@@ -264,6 +264,13 @@ func (g *group) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.Va
 		v, err := g.expr.Parse(branch, parent)
 		if err != nil {
 			ctx.MaybeUpdateError(err)
+			// Fault-tolerant recovery in repetition loops: a malformed element
+			// is skipped forward to the next token that can begin a registered
+			// recovery production, and the loop continues from there.
+			if (g.mode == groupMatchZeroOrMore || g.mode == groupMatchOneOrMore) && ctx.maybeRecover(branch, branch.Peek(), false) {
+				ctx.Accept(branch)
+				continue
+			}
 			// Optional part failed to match.
 			if ctx.Stop(err, branch) {
 				out = append(out, v...) // Try to return as much of the parse tree as possible
@@ -274,6 +281,14 @@ func (g *group) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.Va
 		out = append(out, v...)
 		ctx.Accept(branch)
 		if v == nil {
+			// Fault-tolerant recovery in repetition loops: the expression did
+			// not match, so skip forward to the next token that can begin a
+			// registered recovery production and try again. The failed token
+			// is always consumed, guaranteeing forward progress.
+			if (g.mode == groupMatchZeroOrMore || g.mode == groupMatchOneOrMore) && ctx.maybeRecover(branch, branch.Peek(), false) {
+				ctx.Accept(branch)
+				continue
+			}
 			break
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -32,6 +32,9 @@ type parserOptions struct {
 	unionDefs             []unionDef
 	customDefs            []customDef
 	elide                 []string
+	recoveryDefs          []recoveryDef
+	recovery              []recoverNode
+	structuralLiterals    map[string]bool
 }
 
 // A Parser for a particular grammar and lexer.
@@ -135,6 +138,9 @@ func Build[G any](options ...Option) (parser *Parser[G], err error) {
 	p.typeNodes = context.typeNodes
 	p.typeNodes[p.rootType] = rootNode
 	p.setCaseInsensitiveTokens()
+	if err := p.resolveRecovery(rootNode); err != nil {
+		return nil, err
+	}
 	return p, nil
 }
 
@@ -166,6 +172,9 @@ func (p *Parser[G]) ParseFromLexer(lex *lexer.PeekingLexer, options ...ParseOpti
 		return nil, err
 	}
 	ctx := newParseContext(lex, p.useLookahead, p.caseInsensitiveTokens)
+	ctx.recovery = p.recovery
+	ctx.structural = p.structuralLiterals
+	ctx.lastRecovery = -1
 	defer func() { *lex = ctx.PeekingLexer }()
 	for _, option := range options {
 		option(&ctx)

--- a/recovery.go
+++ b/recovery.go
@@ -1,0 +1,303 @@
+package participle
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+// recoverNode is a registered error-recovery point: a production whose
+// starting tokens act as synchronization points during parsing.
+type recoverNode struct {
+	match func(lexer.Token) bool
+}
+
+type recoveryDef struct {
+	typ reflect.Type
+}
+
+// RecoverTo enables fault-tolerant parsing for the given production types.
+//
+// Each type must correspond to a production in the grammar (a struct type
+// parsed via @@, a union type registered with Union, or a custom type
+// registered with ParseTypeWith). When parsing fails anywhere in the input,
+// the parser scans forward from the error position for the first token that
+// could begin one of the registered productions, skips the malformed region,
+// and resumes parsing from that synchronization point.
+//
+// The partial AST up to the failure is retained; the recovered production's
+// value is not populated, only its starting token is synchronized on. If no
+// synchronization token is found before EOF the original error is returned
+// unchanged.
+//
+// Recovery never crosses structural literals — tokens that appear verbatim in
+// the grammar but are not synchronization points, such as the closing
+// delimiters of enclosing productions. A structural literal that is itself a
+// synchronization point is used directly.
+//
+// Example:
+//
+//	type Statements struct {
+//		Stmts []*Stmt `@@*`
+//	}
+//
+//	parser := participle.MustBuild[Statements](
+//		participle.RecoverTo(&Stmt{}),
+//	)
+func RecoverTo(nodes ...any) Option {
+	return func(p *parserOptions) error {
+		for _, node := range nodes {
+			p.recoveryDefs = append(p.recoveryDefs, recoveryDef{typ: reflect.TypeOf(node)})
+		}
+		return nil
+	}
+}
+
+// resolveRecovery resolves registered recovery definitions against the
+// constructed node graph, computing synchronization predicates for each. It
+// also collects the set of structural literals (tokens that appear verbatim
+// in the grammar) so recovery does not cross them. Must be called after the
+// root production has been parsed and case insensitivity has been configured.
+func (p *parserOptions) resolveRecovery(rootNode node) error {
+	p.recovery = make([]recoverNode, 0, len(p.recoveryDefs))
+	for _, def := range p.recoveryDefs {
+		t := indirectType(def.typ)
+		n, ok := p.typeNodes[t]
+		if !ok {
+			return fmt.Errorf("RecoverTo: parser does not contain a production of type %s", def.typ)
+		}
+		seen := map[node]bool{}
+		matches := startSet(n, seen, p.caseInsensitiveTokens)
+		p.recovery = append(p.recovery, recoverNode{
+			match: func(t lexer.Token) bool { return startSetAny(matches, t) },
+		})
+	}
+	p.structuralLiterals = map[string]bool{}
+	seen := map[node]bool{}
+	err := visit(rootNode, func(n node, next func() error) error {
+		if lit, ok := n.(*literal); ok {
+			p.structuralLiterals[lit.s] = true
+		}
+		if seen[n] {
+			return nil
+		}
+		seen[n] = true
+		return next()
+	})
+	return err
+}
+
+// startSet computes the set of synchronization predicates for the tokens that
+// can begin a match of n. The result is a slice of token predicates; a token
+// can begin n if any predicate matches it. Nodes whose first-token set cannot
+// be statically determined (custom, parseable, negation, lookahead) contribute
+// nothing, so a production rooted at such a node is never a synchronization
+// point.
+func startSet(n node, seen map[node]bool, ci map[lexer.TokenType]bool) []func(lexer.Token) bool {
+	if seen[n] {
+		return nil
+	}
+	seen[n] = true
+	defer delete(seen, n)
+
+	switch n := n.(type) {
+	case *literal:
+		return []func(lexer.Token) bool{
+			func(t lexer.Token) bool {
+				equal := t.Value == n.s
+				if ci[t.Type] && n.s != "" {
+					equal = strings.EqualFold(t.Value, n.s)
+				}
+				return (n.t == lexer.EOF || n.t == t.Type) && equal
+			},
+		}
+
+	case *reference:
+		return []func(lexer.Token) bool{
+			func(t lexer.Token) bool { return t.Type == n.typ },
+		}
+
+	case *strct:
+		return startSet(n.expr, seen, ci)
+
+	case *disjunction:
+		var out []func(lexer.Token) bool
+		for _, alt := range n.nodes {
+			out = append(out, startSet(alt, seen, ci)...)
+		}
+		return out
+
+	case *sequence:
+		out := startSet(n.node, seen, ci)
+		if nullable(n.node, seen) {
+			out = append(out, startSet(n.next, seen, ci)...)
+		}
+		return out
+
+	case *capture:
+		return startSet(n.node, seen, ci)
+
+	case *group:
+		// A group can always begin its inner expression, regardless of mode.
+		return startSet(n.expr, seen, ci)
+
+	case *union:
+		var out []func(lexer.Token) bool
+		for _, member := range n.disjunction.nodes {
+			out = append(out, startSet(member, seen, ci)...)
+		}
+		return out
+
+	case *custom, *parseable, *negation, *lookaheadGroup:
+		return nil
+	}
+	panic(fmt.Sprintf("unhandled node type %T", n))
+}
+
+// startSetAny reports whether any predicate in matches accepts t.
+func startSetAny(matches []func(lexer.Token) bool, t lexer.Token) bool {
+	for _, match := range matches {
+		if match(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// nullable reports whether n can match the empty input. Used to propagate
+// first-token sets through sequences with nullable heads.
+func nullable(n node, seen map[node]bool) bool {
+	if n == nil || seen[n] {
+		return false
+	}
+	seen[n] = true
+	defer delete(seen, n)
+
+	switch n := n.(type) {
+	case *literal, *reference, *custom, *parseable, *negation, *lookaheadGroup:
+		return false
+
+	case *strct:
+		return nullable(n.expr, seen)
+
+	case *disjunction:
+		for _, alt := range n.nodes {
+			if nullable(alt, seen) {
+				return true
+			}
+		}
+		return false
+
+	case *sequence:
+		if !nullable(n.node, seen) {
+			return false
+		}
+		return n.next == nil || nullable(n.next, seen)
+
+	case *capture:
+		return nullable(n.node, seen)
+
+	case *group:
+		switch n.mode {
+		case groupMatchZeroOrOne, groupMatchZeroOrMore:
+			return true
+		case groupMatchOnce, groupMatchOneOrMore, groupMatchNonEmpty:
+			return nullable(n.expr, seen)
+		}
+		return false
+
+	case *union:
+		for _, member := range n.disjunction.nodes {
+			if nullable(member, seen) {
+				return true
+			}
+		}
+		return false
+	}
+	panic(fmt.Sprintf("unhandled node type %T", n))
+}
+
+// maybeRecover attempts to recover from a parse failure by scanning forward
+// for the first token that can begin a registered recovery production.
+//
+// scan is the context to scan (the caller's speculative branch for repetition
+// loops). failed is the token at the scan cursor that failed to parse; it is
+// skipped before searching.
+//
+// consume selects the resume semantics:
+//   - true: the synchronization token is consumed, guaranteeing forward
+//     progress even if the surrounding grammar cannot parse it; used when the
+//     caller will re-attempt parsing from after the sync token.
+//   - false: the synchronization token is not consumed, so the caller can
+//     resume parsing from it; the caller's next iteration is expected to
+//     consume it.
+//
+// Recovery never crosses structural literals (tokens that appear verbatim in
+// the grammar but are not synchronization points), such as the closing
+// delimiters of enclosing productions.
+//
+// A recovery is only attempted if it can make forward progress beyond the
+// last recovery point, which prevents non-terminating recovery loops.
+//
+// On success error state is cleared and true is returned.
+func (p *parseContext) maybeRecover(scan *parseContext, failed *lexer.Token, consume bool) bool {
+	if len(p.recovery) == 0 {
+		return false
+	}
+	start := scan.RawCursor()
+	if !consume && start <= p.lastRecovery {
+		return false
+	}
+	if failed != nil && !failed.EOF() {
+		if p.structural[failed.Value] && !p.isSyncToken(*failed) {
+			return false
+		}
+		if p.isSyncToken(*failed) {
+			if consume {
+				scan.Next()
+			}
+			p.deepestError = nil
+			p.deepestErrorDepth = 0
+			p.lastRecovery = scan.RawCursor()
+			return true
+		}
+		scan.Next() // Skip the token that failed to parse.
+	} else {
+		scan.Next()
+	}
+	for {
+		sync := scan.MakeCheckpoint()
+		tok := scan.Next()
+		if tok.EOF() {
+			return false
+		}
+		for _, rn := range p.recovery {
+			if rn.match(*tok) {
+				if !consume {
+					// Restore the cursor to the synchronization token so the
+					// caller can resume parsing from it.
+					scan.LoadCheckpoint(sync)
+				}
+				p.deepestError = nil
+				p.deepestErrorDepth = 0
+				p.lastRecovery = scan.RawCursor()
+				return true
+			}
+		}
+		if p.structural[tok.Value] {
+			return false
+		}
+	}
+}
+
+// isSyncToken reports whether t can begin any registered recovery production.
+func (p *parseContext) isSyncToken(t lexer.Token) bool {
+	for _, rn := range p.recovery {
+		if rn.match(t) {
+			return true
+		}
+	}
+	return false
+}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -1,0 +1,241 @@
+package participle_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/alecthomas/participle/v2"
+)
+
+// recoverStmt is a statement list with fault-tolerant recovery: a malformed
+// statement is skipped and parsing resumes at the next statement keyword.
+type recoverStmt struct {
+	Stmts []*stmt `@@*`
+}
+
+type stmt struct {
+	If   *ifStmt   `@@`
+	Loop *loopStmt `| @@`
+	Call *callStmt `| @@`
+}
+
+type ifStmt struct {
+	Keyword string   `"if" @Ident "{"`
+	Body    []*stmt  `@@*`
+	Close   struct{} `"}"`
+}
+
+type loopStmt struct {
+	Keyword string   `"loop" @Ident "{"`
+	Body    []*stmt  `@@*`
+	Close   struct{} `"}"`
+}
+
+type callStmt struct {
+	Call string `"call" @Ident`
+}
+
+type recovExpr interface{ recovExpr() }
+
+type numExpr struct {
+	N string `@Int`
+}
+
+func (*numExpr) recovExpr() {}
+
+type addExpr struct {
+	L *numExpr  `@@`
+	R recovExpr `"+" @@`
+}
+
+func (*addExpr) recovExpr() {}
+
+type unionGrammar struct {
+	Exprs []recovExpr `@@*`
+}
+
+func recoverParser(t *testing.T) *participle.Parser[recoverStmt] {
+	t.Helper()
+	parser, err := participle.Build[recoverStmt](
+		participle.RecoverTo(&stmt{}),
+	)
+	assert.NoError(t, err)
+	return parser
+}
+
+func callNames(stmts []*stmt) []string {
+	var names []string
+	for _, s := range stmts {
+		switch {
+		case s.If != nil:
+			names = append(names, "if")
+		case s.Loop != nil:
+			names = append(names, "loop")
+		case s.Call != nil:
+			names = append(names, "call:"+s.Call.Call)
+		}
+	}
+	return names
+}
+
+func TestRecoverToSkipsMalformedStatement(t *testing.T) {
+	parser := recoverParser(t)
+
+	// "broken" cannot begin any statement alternative and must be skipped;
+	// parsing resumes at "call done".
+	actual, err := parser.ParseString("", "call one broken call done")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"call:one", "call:done"}, callNames(actual.Stmts))
+}
+
+func TestRecoverToResumesAfterBrace(t *testing.T) {
+	parser := recoverParser(t)
+
+	// A malformed statement inside a block should skip to the next statement
+	// keyword, even within the same block, without crossing the block's
+	// closing brace.
+	actual, err := parser.ParseString("", "if a { call one broken call two } call after")
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(actual.Stmts))
+	assert.NotEqual(t, (*ifStmt)(nil), actual.Stmts[0].If)
+	ifStmt := actual.Stmts[0].If
+	assert.Equal(t, []string{"call:one", "call:two"}, callNames(ifStmt.Body))
+	assert.Equal(t, "after", actual.Stmts[1].Call.Call)
+}
+
+func TestRecoverToNoSyncTokenReturnsOriginalError(t *testing.T) {
+	parser := recoverParser(t)
+
+	// "broken" has no following statement keyword, so no synchronization
+	// point exists and the original error must be returned.
+	_, err := parser.ParseString("", "call broken @@")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected token")
+}
+
+func TestRecoverToWithoutOptionIsUnchanged(t *testing.T) {
+	parser, err := participle.Build[recoverStmt]()
+	assert.NoError(t, err)
+
+	_, err = parser.ParseString("", "call one broken call done")
+	assert.Error(t, err)
+}
+
+func TestRecoverToSkipsMultipleMalformed(t *testing.T) {
+	parser := recoverParser(t)
+
+	actual, err := parser.ParseString("", "broken1 broken2 call a call b")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"call:a", "call:b"}, callNames(actual.Stmts))
+}
+
+func TestRecoverToUseLookahead(t *testing.T) {
+	parser, err := participle.Build[recoverStmt](
+		participle.UseLookahead(10),
+		participle.RecoverTo(&stmt{}),
+	)
+	assert.NoError(t, err)
+
+	actual, err := parser.ParseString("", "call one broken call two")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"call:one", "call:two"}, callNames(actual.Stmts))
+}
+
+func TestRecoverToCaseInsensitiveLiteral(t *testing.T) {
+	type ciStmt struct {
+		Call string `"CALL" @Ident`
+	}
+	type ciGrammar struct {
+		Stmts []*ciStmt `@@*`
+	}
+	parser, err := participle.Build[ciGrammar](
+		participle.CaseInsensitive("Ident"),
+		participle.RecoverTo(&ciStmt{}),
+	)
+	assert.NoError(t, err)
+
+	// The "CALL" literal is matched case-insensitively, so "call ok" is a
+	// valid statement; "broken" is skipped via recovery.
+	actual, err := parser.ParseString("", "broken call ok")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(actual.Stmts))
+	assert.Equal(t, "ok", actual.Stmts[0].Call)
+}
+
+func TestRecoverToUnknownTypeIsBuildError(t *testing.T) {
+	type unknown struct {
+		X string `@Ident`
+	}
+	_, err := participle.Build[recoverStmt](
+		participle.RecoverTo(&unknown{}),
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not contain a production of type")
+}
+
+func TestRecoverToUnion(t *testing.T) {
+	parser, err := participle.Build[unionGrammar](
+		participle.Union[recovExpr](&addExpr{}, &numExpr{}),
+		participle.RecoverTo(&numExpr{}),
+	)
+	assert.NoError(t, err)
+
+	// "1" parses, "broken" is not a valid expression and is skipped, "2 + 3"
+	// is recovered from the "2".
+	actual, err := parser.ParseString("", "1 broken 2 + 3")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(actual.Exprs))
+}
+
+func TestRecoverToOneOrMore(t *testing.T) {
+	type oneOrMore struct {
+		Stmts []*stmt `@@+`
+	}
+	parser, err := participle.Build[oneOrMore](
+		participle.RecoverTo(&stmt{}),
+	)
+	assert.NoError(t, err)
+
+	actual, err := parser.ParseString("", "call one broken call two")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"call:one", "call:two"}, callNames(actual.Stmts))
+}
+
+func TestRecoverToStructLevelSync(t *testing.T) {
+	parser := recoverParser(t)
+
+	// A broken "if" statement (missing opening brace) whose failure position
+	// lands on a synchronization token ("call"). The partial "if" AST is
+	// retained (best effort) and "call done" is parsed as a new statement.
+	actual, err := parser.ParseString("", "if broken call done")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"if", "call:done"}, callNames(actual.Stmts))
+}
+
+// FuzzRecoverTo ensures recovery never panics or hangs on arbitrary input,
+// even with malformed structures and adversarial token runs.
+func FuzzRecoverTo(f *testing.F) {
+	parser, err := participle.Build[recoverStmt](
+		participle.RecoverTo(&stmt{}),
+	)
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, seed := range []string{
+		"",
+		"call one",
+		"call one broken call two",
+		"if a { broken } call after",
+		"} { [ {",
+		"if broken call done",
+		"loop a { call x } loop b { broken }",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		//nolint:errcheck // any error is an acceptable fuzz outcome.
+		_, _ = parser.ParseString("", in)
+	})
+}


### PR DESCRIPTION
Closes #342

Implements opt-in fault-tolerant parsing via a new `RecoverTo(types...)` build option.

## What it does
When parsing fails, the parser scans forward from the error position for the first token that could **begin** one of the registered productions, skips the malformed region, and resumes parsing from that synchronization point. The partial AST up to the failure is retained (per participle's existing best-effort behavior).

```go
type Statements struct {
    Stmts []*Stmt `@@*`
}

parser := participle.MustBuild[Statements](
    participle.RecoverTo(&Stmt{}),
)
```

Input like `call one broken call two` parses to `[call:one, call:two]` — `broken` is skipped.

## Design
- **Start-set analysis** (`recovery.go`): computes, per registered production, the token predicates that can begin it. Handles `literal` (incl. type constraints and case-insensitivity), `reference`, `strct`, `disjunction`, `sequence` (with nullability propagation through nullable heads), `capture`, `group` and `union`. Opaque nodes (`custom`, `parseable`, `negation`, `lookaheadGroup`) contribute nothing.
- **Forward scan** (`maybeRecover`): scans via a speculative branch (`Next()` skips elided tokens), never crosses **structural literals** (tokens appearing verbatim in the grammar that aren't sync points — e.g. closing delimiters), and guarantees termination via:
  1. the failed token is always consumed, and
  2. a `lastRecovery` cursor guard prevents re-recovering at the same position.
- **Hooks** (`nodes.go`): only inside repetition loops (`group` `*`/`+`), on both the error path and the zero-match path. This keeps the change surgical and avoids the O(n²) blow-up a strct-level hook produced during development.
- **Validation**: `RecoverTo` on a type not in the grammar is a build error.

## Testing
11 unit tests covering: skip-malformed, resume-after-brace (nested blocks, `}` not crossed), no-sync-token falls back to original error, no-option no-op, multiple malformed, `UseLookahead` interaction, case-insensitive literals, unknown-type build error, unions, `@@+` (one-or-more), and struct-level sync on a recursive grammar.

Fuzzed 45s / ~300k executions with **no hang, panic or explosion** (a fuzzer found two non-termination cases during development that the `lastRecovery` guard + structural-literal rules resolved).

## Open question for maintainer
`RecoverTo` is deliberately sync-only (productions are not re-parsed into the AST after recovery); re-parsing recovered nodes would be a natural follow-up but adds complexity. Happy to extend if desired.