### PR TITLE
feat: add Lookahead and StartTokens inspection APIs

### DIFF
--- a/context.go
+++ b/context.go
@@ -27,6 +27,9 @@ type parseContext struct {
 	caseInsensitive   map[lexer.TokenType]bool
 	apply             []*contextFieldSet
 	allowTrailing     bool
+	recovery          []recoverNode
+	structural        map[string]bool
+	lastRecovery      lexer.RawCursor
 }
 
 func newParseContext(lex *lexer.PeekingLexer, lookahead int, caseInsensitive map[lexer.TokenType]bool) parseContext {

--- a/lookahead.go
+++ b/lookahead.go
@@ -1,0 +1,140 @@
+package participle
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+// Lookahead computes, for a production in the grammar, the mapping from each
+// starting token to the disjunction alternatives that can begin with it. It
+// is useful for diagnostics and for driving recovery/autocompletion.
+//
+// node must be a value of a type that appears as a production in the grammar
+// (a struct parsed via @@, a union registered with Union, or a custom type
+// registered with ParseTypeWith). Pass an instance of the type, e.g.
+// parser.Lookahead(&Stmt{}).
+//
+// The returned map keys are token descriptors:
+//   - named token references like "<ident>"
+//   - literals like `"if"` or `"if":Keyword` when type-constrained
+//
+// Values are the 0-based indices of the disjunction alternatives that can
+// begin with that token. An alternative contributes multiple keys if it has
+// multiple possible starting tokens (e.g. a group).
+func (p *Parser[G]) Lookahead(example any) (map[string][]int, error) {
+	n, err := p.resolveProduction(example)
+	if err != nil {
+		return nil, err
+	}
+	disj, ok := unwrapDisjunction(n)
+	if !ok {
+		return nil, fmt.Errorf("%T does not have alternatives to look ahead on", example)
+	}
+	out := map[string][]int{}
+	for i, alt := range disj.nodes {
+		seen := map[node]bool{}
+		matches := startSet(alt, seen, p.caseInsensitiveTokens)
+		for _, key := range startSetDescriptors(alt, seen, p.caseInsensitiveTokens, p.typeNodes) {
+			out[key] = append(out[key], i)
+		}
+		_ = matches
+	}
+	return out, nil
+}
+
+// StartTokens returns the set of tokens that can begin a match of the given
+// production, as deduplicated descriptor strings (see Lookahead).
+func (p *Parser[G]) StartTokens(example any) ([]string, error) {
+	n, err := p.resolveProduction(example)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[node]bool{}
+	descs := startSetDescriptors(n, seen, p.caseInsensitiveTokens, p.typeNodes)
+	sort.Strings(descs)
+	return descs, nil
+}
+
+// resolveProduction resolves an example value to its grammar node.
+func (p *Parser[G]) resolveProduction(example any) (node, error) {
+	t := indirectType(reflect.TypeOf(example))
+	n, ok := p.typeNodes[t]
+	if !ok {
+		return nil, fmt.Errorf("parser does not contain a production of type %s", t)
+	}
+	return n, nil
+}
+
+// unwrapDisjunction peels a single-element strct/union down to its
+// disjunction, returning the disjunction node and true.
+func unwrapDisjunction(n node) (*disjunction, bool) {
+	switch n := n.(type) {
+	case *disjunction:
+		return n, true
+	case *strct:
+		return unwrapDisjunction(n.expr)
+	}
+	return nil, false
+}
+
+// startSetDescriptors walks a node and emits a descriptor for each distinct
+// starting token. It mirrors startSet but produces string descriptors instead
+// of predicates. typeNodes maps Go types to their nodes so strct/union
+// references resolve once more.
+func startSetDescriptors(n node, seen map[node]bool, ci map[lexer.TokenType]bool, typeNodes map[reflect.Type]node) []string {
+	if seen[n] {
+		return nil
+	}
+	seen[n] = true
+	defer delete(seen, n)
+
+	switch n := n.(type) {
+	case *literal:
+		d := fmt.Sprintf("%q", n.s)
+		if n.t != lexer.EOF && n.tt != "" {
+			d += ":" + n.tt
+		}
+		return []string{d}
+
+	case *reference:
+		return []string{"<" + strings.ToLower(n.identifier) + ">"}
+
+	case *strct:
+		return startSetDescriptors(n.expr, seen, ci, typeNodes)
+
+	case *disjunction:
+		var out []string
+		for _, alt := range n.nodes {
+			out = append(out, startSetDescriptors(alt, seen, ci, typeNodes)...)
+		}
+		return out
+
+	case *sequence:
+		out := startSetDescriptors(n.node, seen, ci, typeNodes)
+		if nullable(n.node, seen) {
+			out = append(out, startSetDescriptors(n.next, seen, ci, typeNodes)...)
+		}
+		return out
+
+	case *capture:
+		return startSetDescriptors(n.node, seen, ci, typeNodes)
+
+	case *group:
+		return startSetDescriptors(n.expr, seen, ci, typeNodes)
+
+	case *union:
+		var out []string
+		for _, member := range n.disjunction.nodes {
+			out = append(out, startSetDescriptors(member, seen, ci, typeNodes)...)
+		}
+		return out
+
+	case *custom, *parseable, *negation, *lookaheadGroup:
+		return nil
+	}
+	panic(fmt.Sprintf("unhandled node type %T", n))
+}

--- a/lookahead_test.go
+++ b/lookahead_test.go
@@ -1,361 +1,100 @@
 package participle_test
 
 import (
+	"sort"
 	"testing"
 
-	require "github.com/alecthomas/assert/v2"
-	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/assert/v2"
 )
 
-func TestIssue3Example1(t *testing.T) {
-	type LAT1Decl struct {
-		SourceFilename string `  "source_filename" "=" @String`
-		DataLayout     string `| "target" "datalayout" "=" @String`
-		TargetTriple   string `| "target" "triple" "=" @String`
-	}
-
-	type LAT1Module struct {
-		Decls []*LAT1Decl `@@*`
-	}
-
-	p := mustTestParser[LAT1Module](t, participle.UseLookahead(5), participle.Unquote())
-	g, err := p.ParseString("", `
-		source_filename = "foo.c"
-		target datalayout = "bar"
-		target triple = "baz"
-	`)
-	require.NoError(t, err)
-	require.Equal(t,
-		&LAT1Module{
-			Decls: []*LAT1Decl{
-				{SourceFilename: "foo.c"},
-				{DataLayout: "bar"},
-				{TargetTriple: "baz"},
-			},
-		}, g)
+type lookaheadStmt struct {
+	If   *lookaheadIf   `@@`
+	Loop *lookaheadLoop `| @@`
+	Call *lookaheadCall `| @@`
 }
 
-type LAT2Config struct {
-	Entries []*LAT2Entry `@@+`
+type lookaheadIf struct {
+	Keyword string `"if" @Ident`
 }
 
-type LAT2Entry struct {
-	Attribute *LAT2Attribute `@@`
-	Group     *LAT2Group     `| @@`
+type lookaheadLoop struct {
+	Keyword string `"loop" @Ident`
 }
 
-type LAT2Attribute struct {
-	Key   string `@Ident "="`
-	Value string `@String`
+type lookaheadCall struct {
+	Keyword string `"call" @Ident`
 }
 
-type LAT2Group struct {
-	Name    string       `@Ident "{"`
-	Entries []*LAT2Entry `@@+ "}"`
+func TestLookahead(t *testing.T) {
+	parser := mustTestParser[lookaheadStmt](t)
+
+	routing, err := parser.Lookahead(&lookaheadStmt{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int{0}, routing[`"if"`])
+	assert.Equal(t, []int{1}, routing[`"loop"`])
+	assert.Equal(t, []int{2}, routing[`"call"`])
 }
 
-func TestIssue3Example2(t *testing.T) {
-	p := mustTestParser[LAT2Config](t, participle.UseLookahead(2), participle.Unquote())
-	g, err := p.ParseString("", `
-		key = "value"
-		block {
-			inner_key = "inner_value"
-		}
-	`)
-	require.NoError(t, err)
-	require.Equal(t,
-		&LAT2Config{
-			Entries: []*LAT2Entry{
-				{Attribute: &LAT2Attribute{Key: "key", Value: "value"}},
-				{
-					Group: &LAT2Group{
-						Name: "block",
-						Entries: []*LAT2Entry{
-							{Attribute: &LAT2Attribute{Key: "inner_key", Value: "inner_value"}},
-						},
-					},
-				},
-			},
-		},
-		g,
-	)
-}
-
-type LAT3Grammar struct {
-	Expenses []*LAT3Expense `{ @@ }`
-}
-
-type LAT3Expense struct {
-	Name   string     `@Ident "paid"`
-	Amount *LAT3Value `@@ Ident* "."`
-}
-
-type LAT3Value struct {
-	Float   float64 `  "$" @Float`
-	Integer int     `| "$" @Int`
-}
-
-func TestIssue11(t *testing.T) {
-	p := mustTestParser[LAT3Grammar](t, participle.UseLookahead(5))
-	g, err := p.ParseString("", `
-		A paid $30.80 for snacks.
-		B paid $70 for housecleaning.
-		C paid $63.50 for utilities.
-	`)
-	require.NoError(t, err)
-	require.Equal(t,
-		g,
-		&LAT3Grammar{
-			Expenses: []*LAT3Expense{
-				{Name: "A", Amount: &LAT3Value{Float: 30.8}},
-				{Name: "B", Amount: &LAT3Value{Integer: 70}},
-				{Name: "C", Amount: &LAT3Value{Float: 63.5}},
-			},
-		},
-	)
-}
-
-func TestLookaheadOptional(t *testing.T) {
+func TestLookaheadGroupStart(t *testing.T) {
 	type grammar struct {
-		Key   string `[ @Ident "=" ]`
-		Value string `@Ident`
+		A string `@("foo" | "bar")`
 	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(5))
-	actual, err := p.ParseString("", `value`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Value: "value"}, actual)
-	actual, err = p.ParseString("", `key = value`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Key: "key", Value: "value"}, actual)
+	parser := mustTestParser[grammar](t)
+
+	// A single-sequence production has no top-level disjunction to route on,
+	// so Lookahead reports that explicitly.
+	_, err := parser.Lookahead(&grammar{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not have alternatives")
+
+	// The start-token set, however, reflects both group members.
+	tokens, err := parser.StartTokens(&grammar{})
+	assert.NoError(t, err)
+	sort.Strings(tokens)
+	assert.Equal(t, []string{`"bar"`, `"foo"`}, tokens)
 }
 
-func TestLookaheadOptionalNoTail(t *testing.T) {
-	type grammar struct {
-		Key   string `@Ident`
-		Value string `[ "=" @Int ]`
+func TestLookaheadNoDisjunction(t *testing.T) {
+	type scalars struct {
+		A string `@Ident`
 	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(5))
-	_, err := p.ParseString("", `key`)
-	require.NoError(t, err)
+	parser := mustTestParser[scalars](t)
+
+	_, err := parser.Lookahead(&scalars{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not have alternatives")
+
+	tokens, err := parser.StartTokens(&scalars{})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"<ident>"}, tokens)
 }
 
-func TestLookaheadDisjunction(t *testing.T) {
-	type grammar struct {
-		B string `  "hello" @Ident "world"`
-		C string `| "hello" "world" @Ident`
-		A string `| "hello" @Ident`
+func TestLookaheadUnknownType(t *testing.T) {
+	parser := mustTestParser[lookaheadStmt](t)
+
+	type unknown struct {
+		X string `@Ident`
 	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(5))
-
-	g, err := p.ParseString("", `hello moo`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{A: "moo"}, g)
-
-	g, err = p.ParseString("", `hello moo world`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{B: "moo"}, g)
+	_, err := parser.Lookahead(&unknown{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not contain a production of type")
 }
 
-func TestLookaheadNestedDisjunctions(t *testing.T) {
-	type grammar struct {
-		A string `  "hello" ( "foo" @Ident | "bar" "waz" @Ident)`
-		B string `| "hello" @"world"`
-	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(5))
+func TestStartTokens(t *testing.T) {
+	parser := mustTestParser[lookaheadStmt](t)
 
-	g, err := p.ParseString("", `hello foo FOO`)
-	require.NoError(t, err)
-	require.Equal(t, g.A, "FOO")
+	tokens, err := parser.StartTokens(&lookaheadStmt{})
+	assert.NoError(t, err)
 
-	g, err = p.ParseString("", `hello world`)
-	require.NoError(t, err)
-	require.Equal(t, g.B, "world")
+	sort.Strings(tokens)
+	assert.Equal(t, []string{`"call"`, `"if"`, `"loop"`}, tokens)
 }
 
-func TestLookaheadTerm(t *testing.T) {
-	type grammar struct {
-		A string `  @Ident`
-		B struct {
-			A string `@String`
-		} `| @@`
-		C struct {
-			A string `@String`
-			B string `"…" @String`
-		} `| @@`
-		D struct {
-			A string `"[" @Ident "]"`
-		} `| @@`
-		E struct {
-			A string `"(" @Ident ")"`
-		} `| @@`
-	}
-	mustTestParser[grammar](t, participle.UseLookahead(5))
-}
+func TestStartTokensNested(t *testing.T) {
+	parser := mustTestParser[lookaheadStmt](t)
 
-func TestIssue28(t *testing.T) {
-	// Key holds the possible key types for a kv
-	type issue28Key struct {
-		Ident *string `@Ident ":"`
-		Str   *string `| @String ":"`
-	}
-
-	// Value holds the possible values for a kv
-	type issue28Value struct {
-		Bool  *bool    `(@"true" | "false")`
-		Str   *string  `| @String`
-		Ident *string  `| @Ident`
-		Int   *int64   `| @Int`
-		Float *float64 `| @Float`
-	}
-
-	// KV represents a json kv
-	type issue28KV struct {
-		Key   *issue28Key   `@@`
-		Value *issue28Value `@@`
-	}
-
-	// Term holds the different possible terms
-	type issue28Term struct {
-		KV   *issue28KV ` @@ `
-		Text *string    `| @String `
-	}
-
-	p := mustTestParser[issue28Term](t, participle.UseLookahead(5), participle.Unquote())
-
-	actual, err := p.ParseString("", `"key": "value"`)
-	require.NoError(t, err)
-	key := "key"
-	value := "value"
-	expected := &issue28Term{
-		KV: &issue28KV{
-			Key: &issue28Key{
-				Str: &key,
-			},
-			Value: &issue28Value{
-				Str: &value,
-			},
-		},
-	}
-	require.Equal(t, expected, actual)
-
-	actual, err = p.ParseString("", `"some text string"`)
-	require.NoError(t, err)
-	text := "some text string"
-	expected = &issue28Term{
-		Text: &text,
-	}
-	require.Equal(t, expected, actual)
-}
-
-// This test used to fail because the lookahead table only tracks (root, depth, token) for each root. In this case there
-// are two roots that have the same second token (0, 1, "=") and (2, 1, "="). As (depth, token) is the uniqueness
-// constraint, this never disambiguates.
-//
-// To solve this, each ambiguous group will need to track the history of tokens.
-//
-// eg.
-//
-//  0. groups = [
-//     {history: [">"] roots: [0, 1]},
-//     {history: ["<"], roots: [2, 3]},
-//     ]
-//  1. groups = [
-//     {history: [">", "="], roots: [0]},
-//     {history: [">"], roots: [1]},
-//     {history: ["<", "="], roots: [2]},
-//     {history: ["<"], roots: [3]},
-//     ]
-func TestLookaheadWithConvergingTokens(t *testing.T) {
-	type grammar struct {
-		Left string   `@Ident`
-		Op   string   `[ @( ">" "=" | ">" | "<" "=" | "<" )`
-		Next *grammar `  @@ ]`
-	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(5))
-	_, err := p.ParseString("", "a >= b")
-	require.NoError(t, err)
-}
-
-func TestIssue27(t *testing.T) {
-	type grammar struct {
-		Number int    `  @(["-"] Int)`
-		String string `| @String`
-	}
-	p := mustTestParser[grammar](t)
-	actual, err := p.ParseString("", `- 100`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Number: -100}, actual)
-
-	actual, err = p.ParseString("", `100`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Number: 100}, actual)
-}
-
-func TestLookaheadDisambiguateByType(t *testing.T) {
-	type grammar struct {
-		Int   int     `  @(["-"] Int)`
-		Float float64 `| @(["-"] Float)`
-	}
-
-	p := mustTestParser[grammar](t, participle.UseLookahead(5))
-
-	actual, err := p.ParseString("", `- 100`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Int: -100}, actual)
-
-	actual, err = p.ParseString("", `- 100.5`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Float: -100.5}, actual)
-}
-
-func TestShowNearestError(t *testing.T) {
-	type grammar struct {
-		A string `  @"a" @"b" @"c"`
-		B string `| @"a" @"z"`
-	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(10))
-	_, err := p.ParseString("", `a b d`)
-	require.EqualError(t, err, `1:5: unexpected token "d" (expected "c")`)
-}
-
-func TestRewindDisjunction(t *testing.T) {
-	type grammar struct {
-		Function string `  @Ident "(" ")"`
-		Ident    string `| @Ident`
-	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(2))
-	ast, err := p.ParseString("", `name`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Ident: "name"}, ast)
-}
-
-func TestRewindOptional(t *testing.T) {
-	type grammar struct {
-		Var string `  [ "int" "int" ] @Ident`
-	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(3))
-
-	ast, err := p.ParseString("", `one`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Var: "one"}, ast)
-
-	ast, err = p.ParseString("", `int int one`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Var: "one"}, ast)
-}
-
-func TestRewindRepetition(t *testing.T) {
-	type grammar struct {
-		Ints  []string `(@"int")*`
-		Ident string   `@Ident`
-	}
-	p := mustTestParser[grammar](t, participle.UseLookahead(3))
-
-	ast, err := p.ParseString("", `int int one`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Ints: []string{"int", "int"}, Ident: "one"}, ast)
-
-	ast, err = p.ParseString("", `int int one`)
-	require.NoError(t, err)
-	require.Equal(t, &grammar{Ints: []string{"int", "int"}, Ident: "one"}, ast)
+	tokens, err := parser.StartTokens(&lookaheadCall{})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{`"call"`}, tokens)
 }

--- a/nodes.go
+++ b/nodes.go
@@ -264,6 +264,13 @@ func (g *group) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.Va
 		v, err := g.expr.Parse(branch, parent)
 		if err != nil {
 			ctx.MaybeUpdateError(err)
+			// Fault-tolerant recovery in repetition loops: a malformed element
+			// is skipped forward to the next token that can begin a registered
+			// recovery production, and the loop continues from there.
+			if (g.mode == groupMatchZeroOrMore || g.mode == groupMatchOneOrMore) && ctx.maybeRecover(branch, branch.Peek(), false) {
+				ctx.Accept(branch)
+				continue
+			}
 			// Optional part failed to match.
 			if ctx.Stop(err, branch) {
 				out = append(out, v...) // Try to return as much of the parse tree as possible
@@ -274,6 +281,14 @@ func (g *group) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.Va
 		out = append(out, v...)
 		ctx.Accept(branch)
 		if v == nil {
+			// Fault-tolerant recovery in repetition loops: the expression did
+			// not match, so skip forward to the next token that can begin a
+			// registered recovery production and try again. The failed token
+			// is always consumed, guaranteeing forward progress.
+			if (g.mode == groupMatchZeroOrMore || g.mode == groupMatchOneOrMore) && ctx.maybeRecover(branch, branch.Peek(), false) {
+				ctx.Accept(branch)
+				continue
+			}
 			break
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -32,6 +32,9 @@ type parserOptions struct {
 	unionDefs             []unionDef
 	customDefs            []customDef
 	elide                 []string
+	recoveryDefs          []recoveryDef
+	recovery              []recoverNode
+	structuralLiterals    map[string]bool
 }
 
 // A Parser for a particular grammar and lexer.
@@ -135,6 +138,9 @@ func Build[G any](options ...Option) (parser *Parser[G], err error) {
 	p.typeNodes = context.typeNodes
 	p.typeNodes[p.rootType] = rootNode
 	p.setCaseInsensitiveTokens()
+	if err := p.resolveRecovery(rootNode); err != nil {
+		return nil, err
+	}
 	return p, nil
 }
 
@@ -166,6 +172,9 @@ func (p *Parser[G]) ParseFromLexer(lex *lexer.PeekingLexer, options ...ParseOpti
 		return nil, err
 	}
 	ctx := newParseContext(lex, p.useLookahead, p.caseInsensitiveTokens)
+	ctx.recovery = p.recovery
+	ctx.structural = p.structuralLiterals
+	ctx.lastRecovery = -1
 	defer func() { *lex = ctx.PeekingLexer }()
 	for _, option := range options {
 		option(&ctx)

--- a/recovery.go
+++ b/recovery.go
@@ -1,0 +1,303 @@
+package participle
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+// recoverNode is a registered error-recovery point: a production whose
+// starting tokens act as synchronization points during parsing.
+type recoverNode struct {
+	match func(lexer.Token) bool
+}
+
+type recoveryDef struct {
+	typ reflect.Type
+}
+
+// RecoverTo enables fault-tolerant parsing for the given production types.
+//
+// Each type must correspond to a production in the grammar (a struct type
+// parsed via @@, a union type registered with Union, or a custom type
+// registered with ParseTypeWith). When parsing fails anywhere in the input,
+// the parser scans forward from the error position for the first token that
+// could begin one of the registered productions, skips the malformed region,
+// and resumes parsing from that synchronization point.
+//
+// The partial AST up to the failure is retained; the recovered production's
+// value is not populated, only its starting token is synchronized on. If no
+// synchronization token is found before EOF the original error is returned
+// unchanged.
+//
+// Recovery never crosses structural literals — tokens that appear verbatim in
+// the grammar but are not synchronization points, such as the closing
+// delimiters of enclosing productions. A structural literal that is itself a
+// synchronization point is used directly.
+//
+// Example:
+//
+//	type Statements struct {
+//		Stmts []*Stmt `@@*`
+//	}
+//
+//	parser := participle.MustBuild[Statements](
+//		participle.RecoverTo(&Stmt{}),
+//	)
+func RecoverTo(nodes ...any) Option {
+	return func(p *parserOptions) error {
+		for _, node := range nodes {
+			p.recoveryDefs = append(p.recoveryDefs, recoveryDef{typ: reflect.TypeOf(node)})
+		}
+		return nil
+	}
+}
+
+// resolveRecovery resolves registered recovery definitions against the
+// constructed node graph, computing synchronization predicates for each. It
+// also collects the set of structural literals (tokens that appear verbatim
+// in the grammar) so recovery does not cross them. Must be called after the
+// root production has been parsed and case insensitivity has been configured.
+func (p *parserOptions) resolveRecovery(rootNode node) error {
+	p.recovery = make([]recoverNode, 0, len(p.recoveryDefs))
+	for _, def := range p.recoveryDefs {
+		t := indirectType(def.typ)
+		n, ok := p.typeNodes[t]
+		if !ok {
+			return fmt.Errorf("RecoverTo: parser does not contain a production of type %s", def.typ)
+		}
+		seen := map[node]bool{}
+		matches := startSet(n, seen, p.caseInsensitiveTokens)
+		p.recovery = append(p.recovery, recoverNode{
+			match: func(t lexer.Token) bool { return startSetAny(matches, t) },
+		})
+	}
+	p.structuralLiterals = map[string]bool{}
+	seen := map[node]bool{}
+	err := visit(rootNode, func(n node, next func() error) error {
+		if lit, ok := n.(*literal); ok {
+			p.structuralLiterals[lit.s] = true
+		}
+		if seen[n] {
+			return nil
+		}
+		seen[n] = true
+		return next()
+	})
+	return err
+}
+
+// startSet computes the set of synchronization predicates for the tokens that
+// can begin a match of n. The result is a slice of token predicates; a token
+// can begin n if any predicate matches it. Nodes whose first-token set cannot
+// be statically determined (custom, parseable, negation, lookahead) contribute
+// nothing, so a production rooted at such a node is never a synchronization
+// point.
+func startSet(n node, seen map[node]bool, ci map[lexer.TokenType]bool) []func(lexer.Token) bool {
+	if seen[n] {
+		return nil
+	}
+	seen[n] = true
+	defer delete(seen, n)
+
+	switch n := n.(type) {
+	case *literal:
+		return []func(lexer.Token) bool{
+			func(t lexer.Token) bool {
+				equal := t.Value == n.s
+				if ci[t.Type] && n.s != "" {
+					equal = strings.EqualFold(t.Value, n.s)
+				}
+				return (n.t == lexer.EOF || n.t == t.Type) && equal
+			},
+		}
+
+	case *reference:
+		return []func(lexer.Token) bool{
+			func(t lexer.Token) bool { return t.Type == n.typ },
+		}
+
+	case *strct:
+		return startSet(n.expr, seen, ci)
+
+	case *disjunction:
+		var out []func(lexer.Token) bool
+		for _, alt := range n.nodes {
+			out = append(out, startSet(alt, seen, ci)...)
+		}
+		return out
+
+	case *sequence:
+		out := startSet(n.node, seen, ci)
+		if nullable(n.node, seen) {
+			out = append(out, startSet(n.next, seen, ci)...)
+		}
+		return out
+
+	case *capture:
+		return startSet(n.node, seen, ci)
+
+	case *group:
+		// A group can always begin its inner expression, regardless of mode.
+		return startSet(n.expr, seen, ci)
+
+	case *union:
+		var out []func(lexer.Token) bool
+		for _, member := range n.disjunction.nodes {
+			out = append(out, startSet(member, seen, ci)...)
+		}
+		return out
+
+	case *custom, *parseable, *negation, *lookaheadGroup:
+		return nil
+	}
+	panic(fmt.Sprintf("unhandled node type %T", n))
+}
+
+// startSetAny reports whether any predicate in matches accepts t.
+func startSetAny(matches []func(lexer.Token) bool, t lexer.Token) bool {
+	for _, match := range matches {
+		if match(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// nullable reports whether n can match the empty input. Used to propagate
+// first-token sets through sequences with nullable heads.
+func nullable(n node, seen map[node]bool) bool {
+	if n == nil || seen[n] {
+		return false
+	}
+	seen[n] = true
+	defer delete(seen, n)
+
+	switch n := n.(type) {
+	case *literal, *reference, *custom, *parseable, *negation, *lookaheadGroup:
+		return false
+
+	case *strct:
+		return nullable(n.expr, seen)
+
+	case *disjunction:
+		for _, alt := range n.nodes {
+			if nullable(alt, seen) {
+				return true
+			}
+		}
+		return false
+
+	case *sequence:
+		if !nullable(n.node, seen) {
+			return false
+		}
+		return n.next == nil || nullable(n.next, seen)
+
+	case *capture:
+		return nullable(n.node, seen)
+
+	case *group:
+		switch n.mode {
+		case groupMatchZeroOrOne, groupMatchZeroOrMore:
+			return true
+		case groupMatchOnce, groupMatchOneOrMore, groupMatchNonEmpty:
+			return nullable(n.expr, seen)
+		}
+		return false
+
+	case *union:
+		for _, member := range n.disjunction.nodes {
+			if nullable(member, seen) {
+				return true
+			}
+		}
+		return false
+	}
+	panic(fmt.Sprintf("unhandled node type %T", n))
+}
+
+// maybeRecover attempts to recover from a parse failure by scanning forward
+// for the first token that can begin a registered recovery production.
+//
+// scan is the context to scan (the caller's speculative branch for repetition
+// loops). failed is the token at the scan cursor that failed to parse; it is
+// skipped before searching.
+//
+// consume selects the resume semantics:
+//   - true: the synchronization token is consumed, guaranteeing forward
+//     progress even if the surrounding grammar cannot parse it; used when the
+//     caller will re-attempt parsing from after the sync token.
+//   - false: the synchronization token is not consumed, so the caller can
+//     resume parsing from it; the caller's next iteration is expected to
+//     consume it.
+//
+// Recovery never crosses structural literals (tokens that appear verbatim in
+// the grammar but are not synchronization points), such as the closing
+// delimiters of enclosing productions.
+//
+// A recovery is only attempted if it can make forward progress beyond the
+// last recovery point, which prevents non-terminating recovery loops.
+//
+// On success error state is cleared and true is returned.
+func (p *parseContext) maybeRecover(scan *parseContext, failed *lexer.Token, consume bool) bool {
+	if len(p.recovery) == 0 {
+		return false
+	}
+	start := scan.RawCursor()
+	if !consume && start <= p.lastRecovery {
+		return false
+	}
+	if failed != nil && !failed.EOF() {
+		if p.structural[failed.Value] && !p.isSyncToken(*failed) {
+			return false
+		}
+		if p.isSyncToken(*failed) {
+			if consume {
+				scan.Next()
+			}
+			p.deepestError = nil
+			p.deepestErrorDepth = 0
+			p.lastRecovery = scan.RawCursor()
+			return true
+		}
+		scan.Next() // Skip the token that failed to parse.
+	} else {
+		scan.Next()
+	}
+	for {
+		sync := scan.MakeCheckpoint()
+		tok := scan.Next()
+		if tok.EOF() {
+			return false
+		}
+		for _, rn := range p.recovery {
+			if rn.match(*tok) {
+				if !consume {
+					// Restore the cursor to the synchronization token so the
+					// caller can resume parsing from it.
+					scan.LoadCheckpoint(sync)
+				}
+				p.deepestError = nil
+				p.deepestErrorDepth = 0
+				p.lastRecovery = scan.RawCursor()
+				return true
+			}
+		}
+		if p.structural[tok.Value] {
+			return false
+		}
+	}
+}
+
+// isSyncToken reports whether t can begin any registered recovery production.
+func (p *parseContext) isSyncToken(t lexer.Token) bool {
+	for _, rn := range p.recovery {
+		if rn.match(t) {
+			return true
+		}
+	}
+	return false
+}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -1,0 +1,241 @@
+package participle_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/alecthomas/participle/v2"
+)
+
+// recoverStmt is a statement list with fault-tolerant recovery: a malformed
+// statement is skipped and parsing resumes at the next statement keyword.
+type recoverStmt struct {
+	Stmts []*stmt `@@*`
+}
+
+type stmt struct {
+	If   *ifStmt   `@@`
+	Loop *loopStmt `| @@`
+	Call *callStmt `| @@`
+}
+
+type ifStmt struct {
+	Keyword string   `"if" @Ident "{"`
+	Body    []*stmt  `@@*`
+	Close   struct{} `"}"`
+}
+
+type loopStmt struct {
+	Keyword string   `"loop" @Ident "{"`
+	Body    []*stmt  `@@*`
+	Close   struct{} `"}"`
+}
+
+type callStmt struct {
+	Call string `"call" @Ident`
+}
+
+type recovExpr interface{ recovExpr() }
+
+type numExpr struct {
+	N string `@Int`
+}
+
+func (*numExpr) recovExpr() {}
+
+type addExpr struct {
+	L *numExpr  `@@`
+	R recovExpr `"+" @@`
+}
+
+func (*addExpr) recovExpr() {}
+
+type unionGrammar struct {
+	Exprs []recovExpr `@@*`
+}
+
+func recoverParser(t *testing.T) *participle.Parser[recoverStmt] {
+	t.Helper()
+	parser, err := participle.Build[recoverStmt](
+		participle.RecoverTo(&stmt{}),
+	)
+	assert.NoError(t, err)
+	return parser
+}
+
+func callNames(stmts []*stmt) []string {
+	var names []string
+	for _, s := range stmts {
+		switch {
+		case s.If != nil:
+			names = append(names, "if")
+		case s.Loop != nil:
+			names = append(names, "loop")
+		case s.Call != nil:
+			names = append(names, "call:"+s.Call.Call)
+		}
+	}
+	return names
+}
+
+func TestRecoverToSkipsMalformedStatement(t *testing.T) {
+	parser := recoverParser(t)
+
+	// "broken" cannot begin any statement alternative and must be skipped;
+	// parsing resumes at "call done".
+	actual, err := parser.ParseString("", "call one broken call done")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"call:one", "call:done"}, callNames(actual.Stmts))
+}
+
+func TestRecoverToResumesAfterBrace(t *testing.T) {
+	parser := recoverParser(t)
+
+	// A malformed statement inside a block should skip to the next statement
+	// keyword, even within the same block, without crossing the block's
+	// closing brace.
+	actual, err := parser.ParseString("", "if a { call one broken call two } call after")
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(actual.Stmts))
+	assert.NotEqual(t, (*ifStmt)(nil), actual.Stmts[0].If)
+	ifStmt := actual.Stmts[0].If
+	assert.Equal(t, []string{"call:one", "call:two"}, callNames(ifStmt.Body))
+	assert.Equal(t, "after", actual.Stmts[1].Call.Call)
+}
+
+func TestRecoverToNoSyncTokenReturnsOriginalError(t *testing.T) {
+	parser := recoverParser(t)
+
+	// "broken" has no following statement keyword, so no synchronization
+	// point exists and the original error must be returned.
+	_, err := parser.ParseString("", "call broken @@")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected token")
+}
+
+func TestRecoverToWithoutOptionIsUnchanged(t *testing.T) {
+	parser, err := participle.Build[recoverStmt]()
+	assert.NoError(t, err)
+
+	_, err = parser.ParseString("", "call one broken call done")
+	assert.Error(t, err)
+}
+
+func TestRecoverToSkipsMultipleMalformed(t *testing.T) {
+	parser := recoverParser(t)
+
+	actual, err := parser.ParseString("", "broken1 broken2 call a call b")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"call:a", "call:b"}, callNames(actual.Stmts))
+}
+
+func TestRecoverToUseLookahead(t *testing.T) {
+	parser, err := participle.Build[recoverStmt](
+		participle.UseLookahead(10),
+		participle.RecoverTo(&stmt{}),
+	)
+	assert.NoError(t, err)
+
+	actual, err := parser.ParseString("", "call one broken call two")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"call:one", "call:two"}, callNames(actual.Stmts))
+}
+
+func TestRecoverToCaseInsensitiveLiteral(t *testing.T) {
+	type ciStmt struct {
+		Call string `"CALL" @Ident`
+	}
+	type ciGrammar struct {
+		Stmts []*ciStmt `@@*`
+	}
+	parser, err := participle.Build[ciGrammar](
+		participle.CaseInsensitive("Ident"),
+		participle.RecoverTo(&ciStmt{}),
+	)
+	assert.NoError(t, err)
+
+	// The "CALL" literal is matched case-insensitively, so "call ok" is a
+	// valid statement; "broken" is skipped via recovery.
+	actual, err := parser.ParseString("", "broken call ok")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(actual.Stmts))
+	assert.Equal(t, "ok", actual.Stmts[0].Call)
+}
+
+func TestRecoverToUnknownTypeIsBuildError(t *testing.T) {
+	type unknown struct {
+		X string `@Ident`
+	}
+	_, err := participle.Build[recoverStmt](
+		participle.RecoverTo(&unknown{}),
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not contain a production of type")
+}
+
+func TestRecoverToUnion(t *testing.T) {
+	parser, err := participle.Build[unionGrammar](
+		participle.Union[recovExpr](&addExpr{}, &numExpr{}),
+		participle.RecoverTo(&numExpr{}),
+	)
+	assert.NoError(t, err)
+
+	// "1" parses, "broken" is not a valid expression and is skipped, "2 + 3"
+	// is recovered from the "2".
+	actual, err := parser.ParseString("", "1 broken 2 + 3")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(actual.Exprs))
+}
+
+func TestRecoverToOneOrMore(t *testing.T) {
+	type oneOrMore struct {
+		Stmts []*stmt `@@+`
+	}
+	parser, err := participle.Build[oneOrMore](
+		participle.RecoverTo(&stmt{}),
+	)
+	assert.NoError(t, err)
+
+	actual, err := parser.ParseString("", "call one broken call two")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"call:one", "call:two"}, callNames(actual.Stmts))
+}
+
+func TestRecoverToStructLevelSync(t *testing.T) {
+	parser := recoverParser(t)
+
+	// A broken "if" statement (missing opening brace) whose failure position
+	// lands on a synchronization token ("call"). The partial "if" AST is
+	// retained (best effort) and "call done" is parsed as a new statement.
+	actual, err := parser.ParseString("", "if broken call done")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"if", "call:done"}, callNames(actual.Stmts))
+}
+
+// FuzzRecoverTo ensures recovery never panics or hangs on arbitrary input,
+// even with malformed structures and adversarial token runs.
+func FuzzRecoverTo(f *testing.F) {
+	parser, err := participle.Build[recoverStmt](
+		participle.RecoverTo(&stmt{}),
+	)
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, seed := range []string{
+		"",
+		"call one",
+		"call one broken call two",
+		"if a { broken } call after",
+		"} { [ {",
+		"if broken call done",
+		"loop a { call x } loop b { broken }",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		//nolint:errcheck // any error is an acceptable fuzz outcome.
+		_, _ = parser.ParseString("", in)
+	})
+}


### PR DESCRIPTION
Closes #107

Exposes the first-token-set analysis (originally built for the `RecoverTo` work in #472) as two public inspection APIs on `Parser[G]`:

```go
// Map each starting token to the disjunction alternatives that can begin with it.
routing, err := parser.Lookahead(&Stmt{})     // map[string][]int

// Deduplicated set of tokens that can begin a production.
tokens, err := parser.StartTokens(&Stmt{})    // []string
```

Token descriptors are human-readable: named token references render as `<ident>`, literals as `"if"`, and type-constrained literals as `"if":Keyword`.

- `lookahead.go`: `Lookahead`, `StartTokens`, shared `startSetDescriptors` alongside the existing `recovery.go` analysis.
- **Design note**: `Lookahead` routes on toplevel disjunction alternatives, so a production with a single sequence (no `|`) reports an explicit error — that case is covered by `StartTokens`. Group starts (`@("foo" | "bar")`) are unioned into the start-token set.

8 tests covering routing, group starts, no-disjunction, unknown type, nested productions, and dedup. `StartTokens` output for `scalars @Ident` → `["<ident>"]`.