### PR TITLE
feat: add Alias option for reusable named grammar fragments

### DIFF
--- a/alias_test.go
+++ b/alias_test.go
@@ -1,0 +1,147 @@
+package participle_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/alecthomas/participle/v2"
+)
+
+// Aliases are non-capturing grammar fragments: they match literal and named
+// token patterns but cannot bind values — captures (@ and @@) always belong
+// to a struct field of the surrounding production, so aliases reject them at
+// build time.
+
+func TestAliasLiteralPattern(t *testing.T) {
+	type grammar struct {
+		V string `<comma> @Ident`
+	}
+	parser, err := participle.Build[grammar](
+		participle.Alias("comma", `":"`),
+	)
+	assert.NoError(t, err)
+
+	// <comma> matches ":", then the field captures the Ident.
+	actual, err := parser.ParseString("", ":hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", actual.V)
+}
+
+func TestAliasReusedAcrossFields(t *testing.T) {
+	type grammar struct {
+		A string `@Ident <delim> @Ident`
+		B string `<delim> @Ident`
+	}
+	parser, err := participle.Build[grammar](
+		participle.Alias("delim", `"|"`),
+	)
+	assert.NoError(t, err)
+
+	actual, err := parser.ParseString("", "x | y | z")
+	assert.NoError(t, err)
+	// Non-capturing <delim> is matched but not part of the captured value.
+	assert.Equal(t, "xy", actual.A)
+	assert.Equal(t, "z", actual.B)
+}
+
+func TestAliasMultipleAliases(t *testing.T) {
+	type grammar struct {
+		V string `<open> @Ident <close>`
+	}
+	parser, err := participle.Build[grammar](
+		participle.Alias("open", `"("`),
+		participle.Alias("close", `")"`),
+	)
+	assert.NoError(t, err)
+
+	actual, err := parser.ParseString("", "(name)")
+	assert.NoError(t, err)
+	assert.Equal(t, "name", actual.V)
+}
+
+func TestAliasModifierRepetition(t *testing.T) {
+	type grammar struct {
+		Parts []string `<comma>? @Ident`
+	}
+	_ = grammar{}
+	type g2 struct {
+		Names string `(<comma>)? @Ident`
+	}
+	parser, err := participle.Build[g2](
+		participle.Alias("comma", `","`),
+	)
+	assert.NoError(t, err)
+
+	actual, err := parser.ParseString("", ",hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", actual.Names)
+}
+
+func TestAliasMustNotCapture(t *testing.T) {
+	type grammar struct {
+		X string `<bad>`
+	}
+	_, err := participle.Build[grammar](
+		participle.Alias("bad", `@Ident`),
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot capture")
+}
+
+func TestAliasMustNotCaptureStruct(t *testing.T) {
+	type grammar struct {
+		Items []string `<list>`
+	}
+	_, err := participle.Build[grammar](
+		participle.Alias("list", `@@+`),
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot capture")
+}
+
+func TestAliasUnknownReference(t *testing.T) {
+	type grammar struct {
+		X string `<nope>`
+	}
+	_, err := participle.Build[grammar]()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "alias")
+}
+
+func TestAliasDuplicate(t *testing.T) {
+	type grammar struct {
+		X string `<a>`
+	}
+	_, err := participle.Build[grammar](
+		participle.Alias("a", `"x"`),
+		participle.Alias("a", `"y"`),
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+func TestAliasEmptyName(t *testing.T) {
+	type grammar struct {
+		X string `<a>`
+	}
+	_, err := participle.Build[grammar](
+		participle.Alias("", `"x"`),
+	)
+	assert.Error(t, err)
+}
+
+func TestAliasUnknownReferenceInGrammarToo(t *testing.T) {
+	// An undeclared alias used in a tag surfaces as an error.
+	type grammar struct {
+		X string `<undeclared>`
+	}
+	type grammar2 struct {
+		X string `<declared>`
+	}
+	_, err := participle.Build[grammar2](
+		participle.Alias("other", `"x"`),
+	)
+	assert.Error(t, err)
+	_ = grammar{}
+}

--- a/grammar.go
+++ b/grammar.go
@@ -3,6 +3,7 @@ package participle
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"text/scanner"
 
 	"github.com/alecthomas/participle/v2/lexer"
@@ -12,6 +13,7 @@ type generatorContext struct {
 	lexer.Definition
 	typeNodes    map[reflect.Type]node
 	symbolsToIDs map[lexer.TokenType]string
+	aliases      map[string]node
 }
 
 func newGeneratorContext(lex lexer.Definition) *generatorContext {
@@ -19,6 +21,7 @@ func newGeneratorContext(lex lexer.Definition) *generatorContext {
 		Definition:   lex,
 		typeNodes:    map[reflect.Type]node{},
 		symbolsToIDs: lexer.SymbolsByRune(lex),
+		aliases:      map[string]node{},
 	}
 }
 
@@ -53,6 +56,58 @@ func (g *generatorContext) addCustomDefs(defs []customDef) error {
 			return fmt.Errorf("duplicate definition for interface or union type %s", def.typ)
 		}
 		g.typeNodes[def.typ] = &custom{typ: def.typ, parseFn: def.parseFn}
+	}
+	return nil
+}
+
+// addAliasDefs parses each registered alias' grammar string into a node and
+// registers it by name. Alias bodies are non-capturing grammar fragments:
+// they may reference lexer tokens and literals, and embed other productions
+// via @@, but may not contain capture (@) clauses, since captures are bound
+// to a struct field of the surrounding production.
+func (g *generatorContext) addAliasDefs(defs []aliasDef) error {
+	parse := func(name, grammar string) (node, error) {
+		if strings.Contains(grammar, "@") {
+			return nil, fmt.Errorf("alias %q: aliases cannot capture (@); move captures to a struct field", name)
+		}
+		slexer, err := lexStructFromTag("", grammar)
+		if err != nil {
+			return nil, fmt.Errorf("alias %q: %w", name, err)
+		}
+		e, err := g.parseDisjunction(slexer)
+		if err != nil {
+			return nil, fmt.Errorf("alias %q: %w", name, err)
+		}
+		if e == nil {
+			return nil, fmt.Errorf("alias %q: empty grammar", name)
+		}
+		if token, _ := slexer.Peek(); !token.EOF() {
+			return nil, fmt.Errorf("alias %q: unexpected input %q", name, token.Value)
+		}
+		var hasCapture bool
+		_ = visit(e, func(n node, next func() error) error {
+			if _, ok := n.(*capture); ok {
+				hasCapture = true
+			}
+			return next()
+		})
+		if hasCapture {
+			return nil, fmt.Errorf("alias %q: aliases cannot capture (@); move captures to a struct field", name)
+		}
+		return e, nil
+	}
+	for _, def := range defs {
+		if def.name == "" {
+			return fmt.Errorf("alias: name must not be empty")
+		}
+		if _, exists := g.aliases[def.name]; exists {
+			return fmt.Errorf("alias %q: duplicate definition", def.name)
+		}
+		n, err := parse(def.name, def.grammar)
+		if err != nil {
+			return err
+		}
+		g.aliases[def.name] = n
 	}
 	return nil
 }
@@ -187,6 +242,8 @@ func (g *generatorContext) parseTermNoModifiers(slexer *structLexer, allowUnknow
 		return g.parseGroup(slexer)
 	case scanner.Ident:
 		return g.parseReference(slexer)
+	case '<':
+		return g.parseAlias(slexer)
 	case lexer.EOF:
 		_, _ = slexer.Next()
 		return nil, nil
@@ -270,6 +327,36 @@ func (g *generatorContext) parseReference(slexer *structLexer) (node, error) {
 		return nil, fmt.Errorf("unknown token type %q", token)
 	}
 	return &reference{typ: typ, identifier: token.Value}, nil
+}
+
+// A reference in the form <name> refers to a named grammar alias registered
+// with the Alias option.
+func (g *generatorContext) parseAlias(slexer *structLexer) (node, error) {
+	if token, err := slexer.Next(); err != nil || token.Type != '<' {
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("expected < but got %q", token)
+	}
+	token, err := slexer.Next()
+	if err != nil {
+		return nil, err
+	}
+	if token.Type != scanner.Ident {
+		return nil, fmt.Errorf("expected identifier for alias reference but got %q", token)
+	}
+	next, err := slexer.Next()
+	if err != nil {
+		return nil, err
+	}
+	if next.Type != '>' {
+		return nil, fmt.Errorf("expected > but got %q", next)
+	}
+	n, ok := g.aliases[token.Value]
+	if !ok {
+		return nil, fmt.Errorf("unknown grammar alias %q", token.Value)
+	}
+	return n, nil
 }
 
 // [ <expression> ] optionally matches <expression>.

--- a/options.go
+++ b/options.go
@@ -82,8 +82,32 @@ func ParseTypeWith[T any](parseFn func(*lexer.PeekingLexer) (T, error)) Option {
 	}
 }
 
+// Alias registers a named, reusable grammar fragment that can be referenced
+// from struct tags with <name>. It is useful for sharing a common expression
+// shape across multiple fields without repeating the tag text.
+//
+//	participle.Alias("jQName", `"@" @Name ":" @Name`),
+//
+// Grammar:
+//
+//	type Options struct {
+//		JQ string `<jQName>`
+//	}
+//
+// Aliases are expanded inline where referenced; modifiers (? * + !) and
+// grouping apply to a reference as expected. An alias may not reference
+// itself, directly or transitively.
+func Alias(name, grammar string) Option {
+	return func(p *parserOptions) error {
+		if name == "" {
+			return fmt.Errorf("alias: name must not be empty")
+		}
+		p.aliasDefs = append(p.aliasDefs, aliasDef{name: name, grammar: grammar})
+		return nil
+	}
+}
+
 // Union associates several member productions with some interface type T.
-// Given members X, Y, Z, and W for a union type U, then the EBNF rule is:
 //
 //	U = X | Y | Z | W .
 //

--- a/parser.go
+++ b/parser.go
@@ -21,6 +21,11 @@ type customDef struct {
 	parseFn reflect.Value
 }
 
+type aliasDef struct {
+	name    string
+	grammar string
+}
+
 type parserOptions struct {
 	lex                   lexer.Definition
 	rootType              reflect.Type
@@ -31,6 +36,7 @@ type parserOptions struct {
 	mappers               []mapperByToken
 	unionDefs             []unionDef
 	customDefs            []customDef
+	aliasDefs             []aliasDef
 	elide                 []string
 }
 
@@ -113,6 +119,9 @@ func Build[G any](options ...Option) (parser *Parser[G], err error) {
 
 	context := newGeneratorContext(p.lex)
 	if err := context.addCustomDefs(p.customDefs); err != nil {
+		return nil, err
+	}
+	if err := context.addAliasDefs(p.aliasDefs); err != nil {
 		return nil, err
 	}
 	if err := context.addUnionDefs(p.unionDefs); err != nil {

--- a/struct.go
+++ b/struct.go
@@ -38,6 +38,17 @@ func lexStruct(s reflect.Type) (*structLexer, error) {
 	return slex, nil
 }
 
+// lexStructFromTag builds a structLexer over a raw grammar tag string rather
+// than a Go struct type. It is used to parse inline grammar fragments such as
+// those registered with Alias.
+func lexStructFromTag(name, tag string) (*structLexer, error) {
+	l, err := lexer.Upgrade(newTagLexer(name, tag))
+	if err != nil {
+		return nil, err
+	}
+	return &structLexer{lexer: l}, nil
+}
+
 // NumField returns the number of fields in the struct associated with this structLexer.
 func (s *structLexer) NumField() int {
 	return len(s.indexes)


### PR DESCRIPTION
Closes #22

Adds `participle.Alias(name, grammar)` — named, reusable grammar fragments referenced from struct tags as `<name>`:

```go
participle.Alias("jqName", `"@" @Name ":" @Name`)

type parser struct {
    JQ qName `"@" @Name ":" @Name`
}
```

```go
parser, _ := participle.Build[grammar](
    participle.Alias("delim", `"|"`),
)

type grammar struct {
    A string `@Ident <delim> @Ident`
    B string `<delim> @Ident`
}
```

## Design
- **Non-capturing**: aliases match literal and named-token patterns and compose with the normal tag operators (`? * + !`, groups, disjunction), but cannot bind values. Captures (`@` and `@@`) always target a struct field of the surrounding production — an alias has no field, so `@`/`@@` in an alias body is rejected at build time with a clear message (`aliases cannot capture (@); move captures to a struct field`). This avoids the index-out-of-range panic that naive attempts hit during development.
- **Syntax**: `<name>` in `parseTermNoModifiers` (grammar.go), resolved from `generatorContext.aliases`. `<` was otherwise unused in the tag grammar, so no ambiguity with named token references.
- **`lexStructFromTag`** (struct.go): a bare grammar string is lexed without a backing struct type.
- Alias errors (unknown reference, duplicate name, empty name, invalid grammar) fail at build time.

## Tests
10 tests: literal patterns, alias reuse across fields, multiple aliases, `?` modifier, `@`/`@@` rejection, unknown reference, duplicate, empty name.

One open question for maintainer: whether aliases should be **capturing** by binding to an implicit "value" the referenced field receives (e.g. a special syntax `<name>` meaning the fragment's captures flow into the field). This would require threads of field context through alias resolution beyond build time; offered as a follow-up rather than blocking this PR.