### PR TITLE
perf(parser): reduce allocations in the parse hot path

### DIFF
--- a/context.go
+++ b/context.go
@@ -12,20 +12,20 @@ import (
 type contextFieldSet struct {
 	tokens     []lexer.Token
 	strct      reflect.Value
-	field      structLexerField
+	field      *structLexerField
 	fieldValue []reflect.Value
 }
 
 // Context for a single parse.
 type parseContext struct {
 	lexer.PeekingLexer
-	depth             int
 	trace             io.Writer
+	traceState        *traceState
 	deepestError      error
 	deepestErrorDepth int
 	lookahead         int
 	caseInsensitive   map[lexer.TokenType]bool
-	apply             []*contextFieldSet
+	apply             []contextFieldSet
 	allowTrailing     bool
 }
 
@@ -48,8 +48,8 @@ func (p *parseContext) DeepestError(err error) error {
 }
 
 // Defer adds a function to be applied once a branch has been picked.
-func (p *parseContext) Defer(tokens []lexer.Token, strct reflect.Value, field structLexerField, fieldValue []reflect.Value) {
-	p.apply = append(p.apply, &contextFieldSet{tokens, strct, field, fieldValue})
+func (p *parseContext) Defer(tokens []lexer.Token, strct reflect.Value, field *structLexerField, fieldValue []reflect.Value) {
+	p.apply = append(p.apply, contextFieldSet{tokens, strct, field, fieldValue})
 }
 
 // Apply deferred functions.
@@ -111,13 +111,27 @@ func (p *parseContext) Stop(err error, branch *parseContext) bool {
 func (p *parseContext) hasInfiniteLookahead() bool { return p.lookahead < 0 }
 
 func (p *parseContext) printTrace(n node) func() {
-	if p.trace != nil {
-		tok := p.PeekingLexer.Peek()
-		fmt.Fprintf(p.trace, "%s%q %s\n", strings.Repeat(" ", p.depth*2), tok, n.GoString())
-		p.depth++
-		return func() { p.depth-- }
+	if p.trace == nil {
+		// No tracing: return a static closure that captures nothing, so the
+		// parse context never escapes to the heap.
+		return func() {}
 	}
-	return func() {}
+	if p.traceState == nil {
+		p.traceState = &traceState{w: p.trace}
+	}
+	state := p.traceState
+	tok := p.PeekingLexer.Peek()
+	fmt.Fprintf(state.w, "%s%q %s\n", strings.Repeat(" ", state.depth*2), tok, n.GoString())
+	state.depth++
+	return func() { state.depth-- }
+}
+
+// traceState is the mutable state of the optional parse trace. It is only
+// allocated (and captured by the exit closure) when tracing is enabled, so
+// the common (non-tracing) path never captures the parse context.
+type traceState struct {
+	w     io.Writer
+	depth int
 }
 
 func maxInt(a, b int) int {

--- a/nodes.go
+++ b/nodes.go
@@ -411,7 +411,7 @@ func (c *capture) Parse(ctx *parseContext, parent reflect.Value) (out []reflect.
 	start := ctx.RawCursor()
 	v, err := c.node.Parse(ctx, parent)
 	if v != nil {
-		ctx.Defer(ctx.Range(start, ctx.RawCursor()), parent, c.field, v)
+		ctx.Defer(ctx.Range(start, ctx.RawCursor()), parent, &c.field, v)
 	}
 	if err != nil {
 		return []reflect.Value{parent}, err
@@ -596,7 +596,7 @@ func maybeRef(tmpl reflect.Type, strct reflect.Value) reflect.Value {
 //
 // For all other types, an attempt will be made to convert the string to the corresponding
 // type (int, float32, etc.).
-func setField(tokens []lexer.Token, strct reflect.Value, field structLexerField, fieldValue []reflect.Value) (err error) { //nolint:gocognit
+func setField(tokens []lexer.Token, strct reflect.Value, field *structLexerField, fieldValue []reflect.Value) (err error) { //nolint:gocognit
 	f := strct.FieldByIndex(field.Index)
 
 	// Any kind of pointer, hydrate it first.


### PR DESCRIPTION
Reduces allocations in the parser hot path.

## Results (microc benchmark)

| metric | before | after | delta |
|---|---|---|---|
| allocs/op | 59694 | 55054 | **-7.8%** |
| B/op | 4572762 | 4161671 | **-9.0%** |

ns/op was noisy on the test machine; the allocation/byte reductions are stable and directly reduce GC pressure, which is the dominant cost on this benchmark's CPU profile (mallocgc ≈ 27% of samples).

## Changes

1. **`apply []contextFieldSet` by value** — previously `[]*contextFieldSet`, which heap-allocated a `contextFieldSet` per capture. Now captures are stored inline in the slice; the only allocation is the amortised slice growth.

2. **`contextFieldSet.field` is now `*structLexerField`** — the field comes from the immutable grammar node owned by the parser for its whole lifetime, so a pointer is safe. Shrinks `contextFieldSet` from ~200B to ~88B, halving the cost of slice-growth copies (`Defer` was 5.5k allocs/op).

3. **Decouple the optional trace from `parseContext`** — new `traceState` holds the writer and depth, allocated only when `Trace` is enabled. The deferred exit closure now captures only `traceState`, never the parse context, and the now-unused `depth` field is removed.

## Notes on what I looked at and didn't do

The largest remaining allocation is the ~10.8k/op of `parseContext` branch copies in `disjunction`/`group`. These escape to the heap because `parseable` and `custom` nodes hand `&ctx.PeekingLexer` to user code / `reflect.Call`, which forces Go's escape analysis to treat every `node.Parse(ctx, ...)` interface call as potentially retaining `ctx`. Eliminating those allocations would require pooling or API changes that risk incorrect behaviour if user code retains the lexer, so they're out of scope here.

## Validation

- `go test ./...` passes (full suite, including the trace tests via `participle.Trace`).
- `go vet` clean for the changed package (pre-existing struct-tag warnings in tests remain).
- `gofmt` clean.