### PR TITLE
fix(ebnf): round-trip negation and lookahead assertions

### DIFF
--- a/ebnf/ebnf.go
+++ b/ebnf/ebnf.go
@@ -41,15 +41,19 @@ type Term struct {
 func (t *Term) sealed() {}
 
 func (t *Term) String() string {
+	negation := ""
+	if t.Negation {
+		negation = "~"
+	}
 	switch {
 	case t.Name != "":
-		return t.Name + t.Repetition
+		return negation + t.Name + t.Repetition
 	case t.Literal != "":
-		return t.Literal + t.Repetition
+		return negation + t.Literal + t.Repetition
 	case t.Token != "":
-		return "<" + t.Token + ">" + t.Repetition
+		return negation + "<" + t.Token + ">" + t.Repetition
 	case t.Group != nil:
-		return t.Group.String() + t.Repetition
+		return negation + t.Group.String() + t.Repetition
 	default:
 		panic("??")
 	}
@@ -92,7 +96,7 @@ func (s *SubExpression) sealed() {}
 func (s *SubExpression) String() string {
 	out := "("
 	if s.Lookahead != LookaheadAssertionNone {
-		out += "?" + string(s.Lookahead)
+		out += "?" + string(s.Lookahead) + " "
 	}
 	out += s.Expr.String() + ")"
 	return out

--- a/ebnf/ebnf_test.go
+++ b/ebnf/ebnf_test.go
@@ -13,3 +13,28 @@ func TestEBNF(t *testing.T) {
 	require.NoError(t, err, input)
 	require.Equal(t, input, ast.String())
 }
+
+func TestEBNFRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"NegatedLiteral", `Term = ~"a" .`},
+		{"NegatedToken", `Term = ~<ident> .`},
+		{"NegatedProduction", `Term = ~Production .`},
+		{"NegatedGroup", `Term = ~("a" | "b") .`},
+		{"NegatedRepetition", `Term = ~"a"+ .`},
+		{"PositiveLookahead", `Term = (?= "a") "b" .`},
+		{"NegativeLookahead", `Term = (?! "a") "b" .`},
+		// Verbatim output of Parser.String() for the grammar in
+		// TestEBNF_Other in the root package.
+		{"ParserOutput", `Grammar = ((?= "good") <ident>) | ((?! "bad" | "worse") <ident>) | ~("anything" | "but") .`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ast, err := ParseString(test.input)
+			require.NoError(t, err, test.input)
+			require.Equal(t, test.input, ast.String())
+		})
+	}
+}


### PR DESCRIPTION
`ebnf.ParseString` parses the EBNF that `Parser.String()` emits, and the package's only test asserts that parsing and reprinting is the identity. Two forms do not survive that round trip.

`Term.Negation` is captured by the `@("~")?` tag on `Term` (ebnf/ebnf.go:31), but `Term.String()` (ebnf/ebnf.go:43) never emits it, so `~"a"` prints back as `"a"`. That flips the meaning of the production: the README describes `~<expr>` as matching any token that is *not* the start of the expression. `cmd/railroad/main.go:130` already reads `Term.Negation`, so `Term.String()` was the one consumer of the field that dropped it.

`SubExpression.String()` (ebnf/ebnf.go:92) prints `(?="a")`, but the printer it mirrors emits `(?= "a")` with a space after the assertion (ebnf.go:147 and ebnf.go:149), so lookahead groups do not round trip either.

Neither shows up in `TestEBNF` because the ebnf package's own grammar uses no negation and no lookahead group. Feeding back the string that `TestEBNF_Other` in the root package asserts makes both visible at once:

```
in:  Grammar = ((?= "good") <ident>) | ((?! "bad" | "worse") <ident>) | ~("anything" | "but") .
out: Grammar = ((?="good") <ident>) | ((?!"bad" | "worse") <ident>) | ("anything" | "but") .
```

`Term.String()` now prefixes `~` when `Negation` is set, and `SubExpression.String()` emits the space. The new table-driven test round-trips negated literals, tokens, productions, groups and repetitions, both lookahead assertions, and that `TestEBNF_Other` string verbatim. All 8 subtests fail on master and pass with the change.

Verified on go1.26.4 darwin/arm64 and golangci-lint 2.12.2 with the repo's config:

```
$ go test ./...
ok  github.com/alecthomas/participle/v2               0.263s
ok  github.com/alecthomas/participle/v2/ebnf          1.113s
ok  github.com/alecthomas/participle/v2/lexer         0.715s
ok  github.com/alecthomas/participle/v2/lexer/internal/conformance  3.898s

$ cd _examples && go test ./...   # 20 packages, all ok

$ golangci-lint run               # no output, exit 0
```
